### PR TITLE
Adds DbImportCommand command type

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -63,3 +63,6 @@ class HadoopCommand(Command):
 
 class PigCommand(Command):
     pass
+
+class DbImportCommand(Command):
+    pass


### PR DESCRIPTION
This adds the DbImportCommand command type in the style of other commands to qds_sdk.commands. 
