### PR TITLE
Adds DbImportCommand command type.

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -63,3 +63,6 @@ class HadoopCommand(Command):
 
 class PigCommand(Command):
     pass
+
+class DbImportCommand(Command):
+    pass


### PR DESCRIPTION
Adds DbImportCommand to qds_sdk.commands in the style of the other commands.
