### PR TITLE
Minor change in get_results()

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -122,7 +122,7 @@ class Command(Resource):
         r=conn.get_raw(log_path)
         return r.text
 
-    def get_results(self, fp, inline=True):
+    def get_results(self, fp=sys.stdout, inline=True):
         """
         Fetches the result for the command represented by this object
 


### PR DESCRIPTION
The "fp" param in get_results() defaults to sys.stdout. fp is now optional and get_results() will print results to stdout if fp is not provided. This will maintain backward compatibility with previous SDK versions where get_results() did not have any mandatory parameters.
