### PR TITLE
Parse macros to objects instead of passing it as string all the way to t...

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -21,6 +21,8 @@ import re
 import os
 import pipes
 
+import json
+
 log = logging.getLogger("qds_commands")
 
 # Pattern matcher for s3 path
@@ -212,6 +214,8 @@ class HiveCommand(Command):
                 options.query = q
 
 
+        if options.macros is not None:
+            options.macros = json.loads(options.macros)
         return vars(options)
 
 class HadoopCommand(Command):


### PR DESCRIPTION
macros are stored as a string and passed on to the server. The server does not realize that the string contains a JSON object. If macros is passed as a Python object into the connection object, then the server gets it in the right format.
