### PR TITLE
Added --skip_ssl_cert_check option

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -152,6 +152,10 @@ def main():
                          default=os.getenv('QDS_POLL_INTERVAL'),
                          help="interval for polling API for completion and other events. defaults to 5s")
 
+    optparser.add_option("--skip_ssl_cert_check", dest="skip_ssl_cert_check", action="store_true",
+                         default=False,
+                         help="skip verification of server SSL certificate. Insecure: use with caution.")
+
     optparser.add_option("-v", dest="verbose", action="store_true",
                          default=False,
                          help="verbose mode - info level logging")
@@ -185,11 +189,16 @@ def main():
     if options.poll_interval is None:
         options.poll_interval = 5;
 
+    if options.skip_ssl_cert_check is None:
+        options.skip_ssl_cert_check = False
+    elif options.skip_ssl_cert_check:
+        sys.stderr.write("[WARN] Insecure mode enabled: skipping SSL cert verification\n")
         
     Qubole.configure(api_token=options.api_token,
                      api_url=options.api_url,
                      version=options.api_version,
-                     poll_interval=options.poll_interval)
+                     poll_interval=options.poll_interval,
+                     skip_ssl_cert_check=options.skip_ssl_cert_check)
                      
 
     if len(args) < 1:

--- a/qds_sdk/connection.py
+++ b/qds_sdk/connection.py
@@ -6,7 +6,6 @@ import ssl
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.poolmanager import PoolManager
 from retry import retry
-
 from exception import *
 
 
@@ -25,9 +24,10 @@ class MyAdapter(HTTPAdapter):
 
 class Connection:
 
-    def __init__ (self, auth, base_url, reuse=True):
+    def __init__ (self, auth, base_url, skip_ssl_cert_check, reuse=True):
         self.auth=auth
         self.base_url=base_url
+        self.skip_ssl_cert_check=skip_ssl_cert_check
         self._headers = {'Content-Type': 'application/json'}
 
         self.reuse = reuse
@@ -56,7 +56,8 @@ class Connection:
         else:
             x = requests
             
-        kwargs = {'headers': self._headers, 'auth': self.auth}
+        kwargs = {'headers': self._headers, 'auth': self.auth, 'verify': not self.skip_ssl_cert_check}
+
         if data:
             kwargs['data'] = cjson.encode(data)
 

--- a/qds_sdk/qubole.py
+++ b/qds_sdk/qubole.py
@@ -21,11 +21,12 @@ class Qubole:
     api_token=None
     base_url=None
     poll_interval=None
+    skip_ssl_cert_check=None
 
     @classmethod
     def configure(cls, api_token, 
                   api_url="https://api.qubole.com/api/", version="v1.2", 
-                  poll_interval=5):
+                  poll_interval=5, skip_ssl_cert_check=False):
         """
         Set parameters governing interaction with QDS
         Args:
@@ -38,6 +39,7 @@ class Qubole:
         cls.api_token=api_token
         cls.base_url=os.path.join(api_url, version)
         cls.poll_interval=poll_interval
+        cls.skip_ssl_cert_check=skip_ssl_cert_check
 
 
     cached_agent = None
@@ -53,6 +55,6 @@ class Qubole:
 
 
         if cls.cached_agent is None:
-            cls.cached_agent = Connection(cls._auth, cls.base_url)
+            cls.cached_agent = Connection(cls._auth, cls.base_url, cls.skip_ssl_cert_check)
 
         return cls.cached_agent


### PR DESCRIPTION
This will enable qds.py and the qubole sdk to be used against Qubole API servers having self-signed certs. This is useful for internal, test-oriented Qubole deployments that don't need valid CA certs. 

The default value of  "skip_ssl_cert_check" is false, which will always verify the certificate (which is the current behavior). 

Ran some basic tests with the new option enabled/disabled against https/http and against self-signed certs and valid CA certs. All combinations are working.
