### PR TITLE
Remove unneeded GET call while fetching logs.

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -124,8 +124,7 @@ def getresultaction(cmdclass, args):
 
 def getlogaction(cmdclass, args):
     checkargs_id(args)
-    o = cmdclass.find(args.pop(0))
-    print o.get_log()
+    print cmdclass.get_log_id(args.pop(0))
     return 0
 
 

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -110,6 +110,18 @@ class Command(Resource):
         """
         self.__class__.cancel_id(self.id)
 
+    @classmethod
+    def get_log_id(cls, id):
+        """
+        Fetches log for the command represented by this id
+
+        Args:
+            `id`: command id
+        """
+        conn = Qubole.agent()
+        r = conn.get_raw(cls.element_path(id) + "/logs")
+        return r.text
+
     def get_log(self):
         """
         Fetches log for the command represented by this object


### PR DESCRIPTION
The earlier implementation for getlog first makes a GET call to `commands/id` which returns the following:

```
.
"meta_data": {"results_resource": "commands/id/results", "logs_resource": "commands/id/logs"}
.
```

then it makes a GET call to `meta_data['logs_resource']` which seems to be always equal to `commands/id/logs`. So why not directly make a GET call to `commands/id/logs`.

Can there be a situation when `meta_data['logs_resource']` is not equal to `commands/id/logs`?

cc: @jsensarma, @vrajat, @guptarajat
