### PR TITLE
Add support in the SDK for composite commands.

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -703,7 +703,7 @@ class DbImportCommand(Command):
 
 class CompositeCommand(Command):
     @classmethod
-    def compose(cls, sub_commands, cluster_label=None, notify=False):
+    def compose(cls, sub_commands, macros=None, cluster_label=None, notify=False):
         """
         Args:
             `sub_commands`: list of sub-command dicts
@@ -717,9 +717,12 @@ class CompositeCommand(Command):
             composite = CompositeCommand.compose([cmd1, cmd2])
             cmd = CompositeCommand.run(**composite)
         """
+        if macros is not None:
+            macros = json.loads(macros)
         return {
                 "sub_commands": sub_commands,
                 "command_type": "CompositeCommand",
+                "macros": macros,
                 "label": cluster_label,
                 "can_notify": notify
                }


### PR DESCRIPTION
Things to note:
1. The CLI doesn't support composite commands yet. I don't know of a good way of doing it.
2. If you construct the sub_commands using the parse method of the corresponding
   classes, there would be extra 'can_notify' and 'label' keys inside them
   which the API would ignore. Only the options given directly to the composite
   commands are acted upon by the API.

cc - @mineshpateltc
