### PR TITLE
Fixes #52: pip install fails on non-existent README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,19 +6,21 @@ INSTALL_REQUIRES = ['requests >=1.0.3', 'boto >=2.1.1']
 if sys.version_info < (2, 7, 0):
     INSTALL_REQUIRES.append('argparse>=1.1')
 
+
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
 setup(
-    name = "qds_sdk",
-    version = "1.1.2rc2",
-    author = "Qubole",
-    author_email = "dev@qubole.com",
-    description = ("Python SDK for coding to the Qubole Data Service API"),
-    keywords = "qubole sdk api",
-    url = "https://github.com/qubole/qds-sdk-py",
+    name="qds_sdk",
+    version="1.1.2rc2",
+    author="Qubole",
+    author_email="dev@qubole.com",
+    description=("Python SDK for coding to the Qubole Data Service API"),
+    keywords="qubole sdk api",
+    url="https://github.com/qubole/qds-sdk-py",
     packages=['qds_sdk'],
     scripts=['bin/qds.py'],
+    data_files=[('docs', ['README.rst'])],
     install_requires=INSTALL_REQUIRES,
     long_description=read('README.rst')
-    )
+)


### PR DESCRIPTION
README.rst was not getting packaged in the egg resulting in a failed
install. Including the README.rst file as part of the data_files
catch-all param to bundle the docs

Also fixed the pep8 for setup.py
