### PR TITLE
Gce cluster support

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -170,7 +170,7 @@ def cluster_update_action(clusterclass, args):
 
 
 def _create_cluster_info(arguments):
-    if arguments.aws_access_key_id is None and arguments.account_email is not None:
+    if arguments.aws_access_key_id is None and arguments.client_email is not None:
         # provider is google cloud
         cluster_info = GceClusterInfo(arguments.label,
                                arguments.client_email,
@@ -196,6 +196,17 @@ def _create_cluster_info(arguments):
                                       arguments.vpc_id,
                                       arguments.subnet_id)
 
+        cluster_info.set_spot_instance_settings(
+              arguments.maximum_bid_price_percentage,
+              arguments.timeout_for_request,
+              arguments.maximum_spot_instance_percentage)
+
+        cluster_info.set_stable_spot_instance_settings(
+              arguments.stable_maximum_bid_price_percentage,
+              arguments.stable_timeout_for_request,
+              arguments.stable_allow_fallback)
+
+
     custom_config = None
     if arguments.custom_config_file is not None:
         try:
@@ -211,16 +222,6 @@ def _create_cluster_info(arguments):
                                      arguments.max_nodes,
                                      custom_config,
                                      arguments.slave_request_type)
-
-    cluster_info.set_spot_instance_settings(
-          arguments.maximum_bid_price_percentage,
-          arguments.timeout_for_request,
-          arguments.maximum_spot_instance_percentage)
-
-    cluster_info.set_stable_spot_instance_settings(
-          arguments.stable_maximum_bid_price_percentage,
-          arguments.stable_timeout_for_request,
-          arguments.stable_allow_fallback)
 
     fairscheduler_config_xml = None
     if arguments.fairscheduler_config_xml_file is not None:

--- a/bin/qds.py
+++ b/bin/qds.py
@@ -155,7 +155,7 @@ def checkargs_cluster_id_label(args):
 
 def cluster_create_action(clusterclass, args, provider):
     arguments = clusterclass._parse_create_update(args, provider)
-    cluster_info = _create_cluster_info(arguments)
+    cluster_info = _create_cluster_info(arguments, provider)
     result = clusterclass.create(cluster_info.minimal_payload())
     print(json.dumps(result, indent=4))
     return 0
@@ -163,14 +163,14 @@ def cluster_create_action(clusterclass, args, provider):
 
 def cluster_update_action(clusterclass, args, provider):
     arguments = clusterclass._parse_create_update(args, provider)
-    cluster_info = _create_cluster_info(arguments)
+    cluster_info = _create_cluster_info(arguments, provider)
     result = clusterclass.update(arguments.cluster_id_label, cluster_info.minimal_payload())
     print(json.dumps(result, indent=4))
     return 0
 
 
-def _create_cluster_info(arguments):
-    if hasattr(arguments, 'client_email'):
+def _create_cluster_info(arguments, provider):
+    if provider.lower() == "gce":
         # provider is google cloud
         cluster_info = GceClusterInfo(arguments.label,
                                arguments.client_email,

--- a/bin/qds.py
+++ b/bin/qds.py
@@ -134,7 +134,7 @@ def getlogaction(cmdclass, args):
 def cmdmain(cmd, args):
     cmdclass = CommandClasses[cmd]
 
-    actionset = set(["submit", "run", "check", "cancel", "getresult", "getlog"])
+    actionset = {"submit", "run", "check", "cancel", "getresult", "getlog"}
     if len(args) < 1:
         sys.stderr.write("missing argument containing action\n")
         usage()
@@ -322,7 +322,7 @@ def clustermain(dummy, args, provider):
                          " removed in the next version. Please use 'cluster status'" \
                          " instead.\n")
         clusterclass = HadoopCluster
-        actionset = set(["check"])
+        actionset = {"check"}
 
         if len(args) < 1:
             sys.stderr.write("missing argument containing action\n")
@@ -336,7 +336,7 @@ def clustermain(dummy, args, provider):
 
     else:
         clusterclass = Cluster
-        actionset = set(["create", "delete", "update", "list", "start", "terminate", "status", "reassign_label"])
+        actionset = {"create", "delete", "update", "list", "start", "terminate", "status", "reassign_label"}
 
         if len(args) < 1:
             sys.stderr.write("missing argument containing action\n")
@@ -393,7 +393,7 @@ def main():
                          default=False,
                          help="skip verification of server SSL certificate. Insecure: use with caution.")
 
-    optparser.add_option("--provider", dest="provider", default="aws",
+    optparser.add_option("--provider", dest="provider", default="aws", choices=["aws", "gce", "azure"],
                          help="IaaS cloud provider you are using with Qubole. Default: AWS")
 
     optparser.add_option("-v", dest="verbose", action="store_true",

--- a/bin/qds.py
+++ b/bin/qds.py
@@ -170,17 +170,31 @@ def cluster_update_action(clusterclass, args):
 
 
 def _create_cluster_info(arguments):
-    cluster_info = ClusterInfo(arguments.label,
-                               arguments.aws_access_key_id,
-                               arguments.aws_secret_access_key,
+    if arguments.aws_access_key_id is None and arguments.account_email is not None:
+        # provider is google cloud
+        cluster_info = GceClusterInfo(arguments.label,
+                               arguments.client_email,
+                               arguments.private_key,
+                               arguments.project_id,
                                arguments.disallow_cluster_termination,
                                arguments.enable_ganglia_monitoring,
                                arguments.node_bootstrap_file,)
 
-    cluster_info.set_ec2_settings(arguments.aws_region,
-                                  arguments.aws_availability_zone,
-                                  arguments.vpc_id,
-                                  arguments.subnet_id)
+        cluster_info.set_gce_settings(arguments.region,
+                                  arguments.availability_zone)
+    else:
+        # defaults to AWS EC2 provider
+        cluster_info = AwsClusterInfo(arguments.label,
+                                   arguments.aws_access_key_id,
+                                   arguments.aws_secret_access_key,
+                                   arguments.disallow_cluster_termination,
+                                   arguments.enable_ganglia_monitoring,
+                                   arguments.node_bootstrap_file,)
+
+        cluster_info.set_ec2_settings(arguments.aws_region,
+                                      arguments.aws_availability_zone,
+                                      arguments.vpc_id,
+                                      arguments.subnet_id)
 
     custom_config = None
     if arguments.custom_config_file is not None:

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -202,7 +202,7 @@ class Cluster(Resource):
         hadoop_group.add_argument("--slave-request-type",
                                       dest="slave_request_type",
                                       choices=["ondemand", "spot", "hybrid"],
-                                      help="purchasing option for slave instaces", )
+                                      help="purchasing option for slave instances", )
 
         if provider.lower() == "aws":
             spot_group = argparser.add_argument_group("spot instance settings" +
@@ -647,8 +647,21 @@ class GceClusterInfo(ClusterInfo):
         """
         self.label = label
         super(GceClusterInfo, self).__init__()
+
+        # Read the PKCS12 format key
+        try:
+            key_file = open(private_key, 'r')
+            try:
+                pkc12_key = key_file.read()
+            except IOError, io:
+                raise "Error reading private key %s" % io
+            finally:
+                key_file.close()
+        except IOError, opex:
+            raise "Error opening private key %s" % opex
+
         # Google Cloud Platform settings
-        self.gce_settings = {'client_email': client_email, 'private_key': private_key, 'project_id': project_id}
+        self.gce_settings = {'client_email': client_email, 'private_key': pkc12_key, 'project_id': project_id}
         self.disallow_cluster_termination = disallow_cluster_termination
         self.enable_ganglia_monitoring = enable_ganglia_monitoring
         self.node_bootstrap_file = node_bootstrap_file

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -203,6 +203,9 @@ class Cluster(Resource):
                                       dest="slave_request_type",
                                       choices=["ondemand", "spot", "hybrid"],
                                       help="purchasing option for slave instances", )
+        hadoop_group.add_argument("--use-hbase", dest="use_hbase",
+                             action="store_true", default=None,
+                             help="Use hbase on this cluster",)
 
         if provider.lower() == "aws":
             spot_group = argparser.add_argument_group("spot instance settings" +

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -400,7 +400,7 @@ class Cluster(Resource):
         return conn.delete(cls.element_path(cluster_id_label))
 
 
-class ClusterInfo():
+class ClusterInfo(object):
     """
     qds_sdk.ClusterInfo is the class which stores information about a cluster.
     You can use objects of this class to create or update a cluster.

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -648,10 +648,7 @@ class GceClusterInfo(ClusterInfo):
         self.label = label
         super(GceClusterInfo, self).__init__()
         # Google Cloud Platform settings
-        self.gce_settings = {}
-        self.gce_settings['client_email'] = client_email
-        self.gce_settings['private_key'] = private_key
-        self.gce_settings['project_id'] = project_id
+        self.gce_settings = {'client_email': client_email, 'private_key': private_key, 'project_id': project_id}
         self.disallow_cluster_termination = disallow_cluster_termination
         self.enable_ganglia_monitoring = enable_ganglia_monitoring
         self.node_bootstrap_file = node_bootstrap_file

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -136,22 +136,18 @@ class Cluster(Resource):
                                     " (atleast one label is required)")
 
         gce_group = argparser.add_argument_group("gce settings")
-        gce_group.add_argument("--account-email",
-                               dest="account_email",
-                               required=create_required,
+        gce_group.add_argument("--client-email",
+                               dest="client_email",
                                help="email of the google cloud project account")
         gce_group.add_argument("--private-key",
                                dest="private_key",
-                               required=create_required,
                                help="path to the client private key file"
                                     "of your google cloud project")
         gce_group.add_argument("--project-id",
                                dest="project_id",
-                               required=create_required,
                                help="name of your google cloud project")
         gce_group.add_argument("--region",
                                dest="region",
-                               required=create_required,
                                default="us-central1",
                                help="google cloud region")
         gce_group.add_argument("-z", "--availability-zone",
@@ -162,13 +158,11 @@ class Cluster(Resource):
         ec2_group = argparser.add_argument_group("ec2 settings")
         ec2_group.add_argument("--access-key-id",
                                dest="aws_access_key_id",
-                               required=create_required,
                                help="access key id for customer's aws" +
                                     " account. This is required while" +
                                     " creating the cluster",)
         ec2_group.add_argument("--secret-access-key",
                                dest="aws_secret_access_key",
-                               required=create_required,
                                help="secret access key for customer's aws" +
                                     " account. This is required while" +
                                     " creating the cluster",)

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -219,6 +219,24 @@ class TestClusterCreate(QdsCliTestCase):
                     }
                 })
 
+    def test_disallow_cluster_termination_gce(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--disallow-cluster-termination']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email': 'someone@example.com',
+                                      'private_key' : '/path/to/key.pem',
+                                      'project_id'  : 'mycompany-gce',
+                                      'region'      : 'us-central1'},
+                     'disallow_cluster_termination': True
+                    }
+                })
+
     def test_allow_cluster_termination(self):
         sys.argv = ['qds.py', 'cluster', 'create', '--label', 'test_label',
                 '--access-key-id', 'aki', '--secret-access-key', 'sak',
@@ -231,6 +249,24 @@ class TestClusterCreate(QdsCliTestCase):
                     {'label': ['test_label'],
                      'ec2_settings': {'compute_secret_key': 'sak',
                                       'compute_access_key': 'aki'},
+                     'disallow_cluster_termination': False
+                    }
+                })
+
+    def test_allow_cluster_termination_gce(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--allow-cluster-termination']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email': 'someone@example.com',
+                                      'private_key' : '/path/to/key.pem',
+                                      'project_id'  : 'mycompany-gce',
+                                      'region'      : 'us-central1'},
                      'disallow_cluster_termination': False
                     }
                 })
@@ -433,6 +469,40 @@ class TestClusterCreate(QdsCliTestCase):
         with self.assertRaises(SystemExit):
             qds.main()
 
+    def test_gce_region_us_central1(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--region', 'us-central1']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email'  : 'someone@example.com',
+                                      'private_key'   : '/path/to/key.pem',
+                                      'project_id'    : 'mycompany-gce',
+                                      'region'        : 'us-central1'},
+                    }
+                })
+
+    def test_gce_region_europe_west1(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--region', 'europe-west1']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email'  : 'someone@example.com',
+                                      'private_key'   : '/path/to/key.pem',
+                                      'project_id'    : 'mycompany-gce',
+                                      'region'        : 'europe-west1'},
+                    }
+                })
+
     def test_aws_availability_zone(self):
         sys.argv = ['qds.py', 'cluster', 'create', '--label', 'test_label',
                 '--access-key-id', 'aki', '--secret-access-key', 'sak',
@@ -446,6 +516,25 @@ class TestClusterCreate(QdsCliTestCase):
                      'ec2_settings': {'compute_secret_key': 'sak',
                                       'compute_access_key': 'aki',
                                       'aws_preferred_availability_zone': 'us-east-1a'},
+                    }
+                })
+
+    def test_gce_availability_zone(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--region', 'europe-west1',
+                '-z', 'europe-west1-b']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email'  : 'someone@example.com',
+                                      'private_key'   : '/path/to/key.pem',
+                                      'project_id'    : 'mycompany-gce',
+                                      'region'        : 'europe-west1',
+                                      'availability_zone' : 'europe-west1-b'},
                     }
                 })
 
@@ -482,6 +571,24 @@ class TestClusterCreate(QdsCliTestCase):
                     }
                 })
 
+    def test_master_instance_type_gce(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--master-instance-type', 'n1-standard-1']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email'  : 'someone@example.com',
+                                      'private_key'   : '/path/to/key.pem',
+                                      'project_id'    : 'mycompany-gce',
+                                      'region'        : 'us-central1'},
+                     'hadoop_settings': {'master_instance_type' : 'n1-standard-1'}
+                    }
+                })
+
     def test_slave_instance_type(self):
         sys.argv = ['qds.py', 'cluster', 'create', '--label', 'test_label',
                 '--access-key-id', 'aki', '--secret-access-key', 'sak',
@@ -495,6 +602,24 @@ class TestClusterCreate(QdsCliTestCase):
                      'ec2_settings': {'compute_secret_key': 'sak',
                                       'compute_access_key': 'aki'},
                      'hadoop_settings': {'slave_instance_type': 'm1.large'}
+                    }
+                })
+
+    def test_slave_instance_type_gce(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--slave-instance-type', 'n1-standard-1']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'cluster':
+                    {'label': ['test_label'],
+                     'gce_settings': {'client_email'  : 'someone@example.com',
+                                      'private_key'   : '/path/to/key.pem',
+                                      'project_id'    : 'mycompany-gce',
+                                      'region'        : 'us-central1'},
+                     'hadoop_settings': {'slave_instance_type' : 'n1-standard-1'}
                     }
                 })
 

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -843,6 +843,15 @@ class TestClusterCreate(QdsCliTestCase):
         with self.assertRaises(SystemExit):
             qds.main()
 
+    def test_aws_spot_market_on_gce(self):
+        sys.argv = ['qds.py', '--provider=gce', 'cluster', 'create', '--label', 'test_label',
+                '--client-email', 'someone@example.com', '--private-key', '/path/to/key.pem',
+                '--project-id', 'mycompany-gce', '--maximum-bid-price-percentage', '80']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
     def test_encrypted_ephemerals(self):
         sys.argv = ['qds.py', 'cluster', 'create', '--label', 'test_label',
                 '--access-key-id', 'aki', '--secret-access-key', 'sak',


### PR DESCRIPTION
[WIP] still need to add tests for some negative scenarios.

This PR brings basic cluster support for the GCE offering of Qubole. For the SDK, I have abstracted the ClusterInfo object to be of two types `AwsClusterInfo` and `GceClusterInfo`. Each provider's authentication mechanism differing, I have altered the cluster settings to include context specific arguments. So when the `--provider` argument is explicitly used to switch providers we only show cluster arguments of that provider. Some of the provider specific features like EC2's `spot_instances` are hidden from the google cloud users.

Some of the parsing done by the OptionParser in `qds.py` is kludgy and I intend to clean it up over a separate commit to make the multi-cloud parsing easier.