### PR TITLE
Add trove classifiers.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,16 @@ setup(
     packages=['qds_sdk'],
     scripts=['bin/qds.py'],
     install_requires=INSTALL_REQUIRES,
-    long_description=read('README.rst')
+    long_description=read('README.rst'),
+    classifiers=[
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.6",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.3",
+        "Programming Language :: Python :: 3.4"
+    ]
     )


### PR DESCRIPTION
Add trove classifiers for Python 3. This makes http://py3readiness.org display the status of this package correctly :).
