### PR TITLE
new: usr: zendesk-626: Option to print command logs to stderr when using 'run' action.

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -80,6 +80,7 @@ def checkargs_id(args):
 
 def submitaction(cmdclass, args):
     args = cmdclass.parse(args)
+    args.pop("print_logs") # This is only useful while using the 'run' action.
     if args is not None:
         cmd = cmdclass.create(**args)
         print("Submitted %s, Id: %s" % (cmdclass.__name__, cmd.id))
@@ -98,8 +99,11 @@ def _getresult(cmdclass, cmd):
 
 def runaction(cmdclass, args):
     args = cmdclass.parse(args)
+    print_logs = args.pop("print_logs") # We don't want to send this to the API.
     if args is not None:
         cmd = cmdclass.run(**args)
+        if print_logs:
+            sys.stderr.write(cmd.get_log())
         return _getresult(cmdclass, cmd)
 
 

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -201,6 +201,9 @@ class HiveCommand(Command):
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this query")
 
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
+
     @classmethod
     def parse(cls, args):
         """
@@ -280,6 +283,9 @@ class PrestoCommand(Command):
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this query")
 
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
+
     @classmethod
     def parse(cls, args):
         """
@@ -350,6 +356,9 @@ class HadoopCommand(Command):
     optparser.add_option("--tags", dest="tags",
                          help="comma-separated list of tags to be associated with the query ( e.g., tag1 tag1,tag2 )")
 
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
+
     optparser.disable_interspersed_args()
 
     @classmethod
@@ -381,6 +390,7 @@ class HadoopCommand(Command):
         parsed['name'] = options.name
         parsed['tags'] = options.tags
         parsed["command_type"] = "HadoopCommand"
+        parsed['print_logs'] = options.print_logs
 
         if len(args) < 2:
             raise ParseError("Need at least two arguments", cls.usage)
@@ -422,6 +432,9 @@ class ShellCommand(Command):
 
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this command")
+
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
 
     @classmethod
     def parse(cls, args):
@@ -512,6 +525,9 @@ class PigCommand(Command):
 
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this command")
+
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
 
     @classmethod
     def parse(cls, args):
@@ -625,6 +641,9 @@ class DbExportCommand(Command):
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this command")
 
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
+
     @classmethod
     def parse(cls, args):
         """
@@ -722,6 +741,9 @@ class DbImportCommand(Command):
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this command")
 
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
+
     @classmethod
     def parse(cls, args):
         """
@@ -805,6 +827,9 @@ class DbTapQueryCommand(Command):
                          help="comma-separated list of tags to be associated with the query ( e.g., tag1 tag1,tag2 )")
     optparser.add_option("--name", dest="name",
                          help="Assign a name to this command")
+
+    optparser.add_option("--print-logs", action="store_true", dest="print_logs",
+                         default=False, help="Fetch logs and print them to stderr.")
 
     @classmethod
     def parse(cls, args):


### PR DESCRIPTION
You can now do something like this:
```
qds.py hivecmd run --print-logs --query 'show tables'
```
and it will print the logs to the stderr, in addition to printing the results to stdout.

PS: We need a rewrite of the SDK - it's getting too messy. :-(