### PR TITLE
Fix for #99 : Unreleased versions

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -43,7 +43,7 @@ usage_str = ("Usage: \n"
              "  getresult <id> : get the results for the cmd with this Id\n"
              "  getlog <id> : get the logs for the cmd with this Id\n"
              "\nClusterArgs:\n" +
-             "  cluster <create|delete|update|list|start|terminate|status|reassign_label> [args .. ]\n"
+             "  cluster <create|delete|update|list|start|terminate|status|reassign_label|snapshot|restore_point> [args .. ]\n"
              "  create [cmd-specific-args ..] : create a new cluster\n"
              "  delete [cmd-specific-args ..] : delete an existing cluster\n"
              "  update [cmd-specific-args ..] : update the settings of an existing cluster\n"
@@ -53,6 +53,8 @@ usage_str = ("Usage: \n"
              "  terminate [cmd-specific-args ..] : terminate a running cluster\n"
              "  status [cmd-specific-args ..] : show whether the cluster is up or down\n" +
              "  reassign_label [cmd-specific-args ..] : reassign label from one cluster to another\n" +
+             "  snapshot [cmd-specific-args ..] : take snapshot of cluster\n" +
+             "  restore_point [cmd-specific-args ..] : restore cluster from snapshot\n" +
              "\nDbTap:\n" +
              "  dbtap --help\n" +
              "\nReportArgs:\n" +
@@ -325,10 +327,21 @@ def cluster_reassign_label_action(clusterclass, args):
     print(json.dumps(result, indent=4))
     return 0
 
+def cluster_snapshot_action(clusterclass, args):
+    arguments = clusterclass._parse_snapshot_restore_command(args, "snapshot")
+    result = clusterclass.snapshot(arguments.cluster_id or arguments.label, arguments.s3_location, arguments.backup_type)
+    print(json.dumps(result, indent=4))
+    return 0
+
+def cluster_restore_point_action(clusterclass, args):
+    arguments = clusterclass._parse_snapshot_restore_command(args, "restore_point")
+    result = clusterclass.restore_point(arguments.cluster_id or arguments.label, arguments.s3_location, arguments.backup_id, arguments.table_names)
+    print(json.dumps(result, indent=4))
+    return 0
 
 def clustermain(args):
     clusterclass = Cluster
-    actionset = set(["create", "delete", "update", "clone", "list", "start", "terminate", "status", "reassign_label"])
+    actionset = set(["create", "delete", "update", "clone", "list", "start", "terminate", "status", "reassign_label", "snapshot", "restore_point"])
 
     if len(args) < 1:
         sys.stderr.write("missing argument containing action\n")

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -415,6 +415,56 @@ class Cluster(Resource):
         conn = Qubole.agent()
         return conn.delete(cls.element_path(cluster_id_label))
 
+    @classmethod
+    def _parse_snapshot_restore_command(cls, args, action):
+        """
+        Parse command line arguments for snapshot command.
+        """
+        argparser = ArgumentParser(prog="cluster %s" % action)
+        
+        group = argparser.add_mutually_exclusive_group(required=True)
+        group.add_argument("--id", dest="cluster_id",
+                          help="execute on cluster with this id")
+        group.add_argument("--label", dest="label",
+                          help="execute on cluster with this label")
+        argparser.add_argument("--s3_location",
+                          help="s3_location where backup is stored", required=True)
+        if action == "snapshot":
+            argparser.add_argument("--backup_type",
+                          help="backup_type: full/incremental, default is full")
+        elif action == "restore_point":
+            argparser.add_argument("--backup_id",
+                          help="back_id from which restoration will be done", required=True)
+            argparser.add_argument("--table_names",
+                          help="table(s) which are to be restored", required=True)
+        
+        arguments = argparser.parse_args(args)
+
+        return arguments
+
+    @classmethod
+    def snapshot(cls, cluster_id_label, s3_location, backup_type):
+        """
+        Create hbase snapshot full/incremental
+        """
+        conn = Qubole.agent()
+        parameters = {}
+        parameters['s3_location'] = s3_location
+        if backup_type:
+            parameters['backup_type'] = backup_type
+        return conn.post(cls.element_path(cluster_id_label) + "/snapshot", data={"parameters" : parameters})
+
+    @classmethod
+    def restore_point(cls, cluster_id_label, s3_location, backup_id, table_names):
+        """
+        Restoring cluster from a given hbase snapshot id
+        """
+        conn = Qubole.agent()
+        parameters = {}
+        parameters['s3_location'] = s3_location
+        parameters['backup_id'] = backup_id
+        parameters['table_names'] = table_names
+        return conn.post(cls.element_path(cluster_id_label) + "/restore_point", data={"parameters" : parameters})
 
 class ClusterInfo():
     """

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="qds_sdk",
-    version="1.4.3",
+    version="unreleased",
     author="Qubole",
     author_email="dev@qubole.com",
     description=("Python SDK for coding to the Qubole Data Service API"),

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1519,5 +1519,70 @@ class TestClusterClone(QdsCliTestCase):
                                                     }
                                                 })
 
+class TestClusterHbaseSnapshot(QdsCliTestCase):
+    
+    def test_snapshot(self):
+        sys.argv = ['qds.py', 'cluster', 'snapshot', '--label', '1234', '--s3_location', 'myString', '--backup_type', 'full']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshot', {'parameters':  {'s3_location':'myString', 'backup_type':'full'}})
+
+    def test_snapshot_with_no_label(self):
+        sys.argv = ['qds.py', 'cluster', 'snapshot', '--s3_location', 'myString', '--backup_type', 'full']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_snapshot_with_no_s3_location(self):
+        sys.argv = ['qds.py', 'cluster', 'snapshot', '--label', '1234', '--backup_type', 'full']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_snapshot_with_no_backup_type(self):
+        sys.argv = ['qds.py', 'cluster', 'snapshot', '--label', '1234', '--s3_location', 'myString']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshot', {'parameters':  {'s3_location':'myString'}})
+
+    def test_restore_point(self):
+        sys.argv = ['qds.py', 'cluster', 'restore_point', '--label', '1234', '--s3_location', 'myString', '--backup_id', 'abcd', '--table_names', 'tablename']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters/1234/restore_point', {'parameters':  {'s3_location':'myString', 'backup_id':'abcd', 'table_names':'tablename'}})
+
+    def test_restore_point_with_no_label(self):
+        sys.argv = ['qds.py', 'cluster', 'restore_point', '--s3_location', 'myString', '--backup_id', 'abcd', '--table_names', 'tablename']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_restore_point_with_no_s3_location(self):
+        sys.argv = ['qds.py', 'cluster', 'restore_point', '--label', '1234', '--backup_id', 'abcd', '--table_names', 'tablename']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_restore_point_with_no_backup_id(self):
+        sys.argv = ['qds.py', 'cluster', 'restore_point', '--label', '1234','--s3_location', 'myString', '--table_names', 'tablename']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_restore_point_with_no_table_names(self):
+        sys.argv = ['qds.py', 'cluster', 'restore_point', '--label', '1234','--s3_location', 'myString', '--backup_id', 'abcd']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The `setup.py`'s setup() method indicates the stable version to be installed. Because the unreleased branch of qds-sdk has `1.4.3` as the stable version, downstream tools that want the unreleased versions by specifying a github dependency pointed to the unreleased branch will fail to install. This is because setuptools finds `1.4.3` to be stable over `unreleased` and always override with what is found in PyPi. In order to  install `unreleased` versions the "stable" version in the unreleased branch should be made `unreleased`