### PR TITLE
fix #99: setup.py should indicate unreleased branch as version==unrelea...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="qds_sdk",
-    version="1.4.3",
+    version="unreleased",
     author="Qubole",
     author_email="dev@qubole.com",
     description=("Python SDK for coding to the Qubole Data Service API"),


### PR DESCRIPTION
fixes #99 The `setup.py`'s setup() method indicates the stable version to be installed. Because the unreleased branch of qds-sdk has `1.4.3` as the stable version, downstream tools that want the unreleased versions by specifying a github dependency pointed to the unreleased branch will fail to install. This is because setuptools finds `1.4.3` to be stable over `unreleased` and always override with what is found in PyPi. In order to  install `unreleased` versions the "stable" version in the unreleased branch should be made `unreleased`