### PR TITLE
Move snapshots api

### DIFF
--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -528,7 +528,7 @@ class Cluster(Resource):
         parameters['s3_location'] = s3_location
         if backup_type:
             parameters['backup_type'] = backup_type
-        return conn.post(cls.element_path(cluster_id_label) + "/snapshot", data=parameters)
+        return conn.post(cls.element_path(cluster_id_label) + "/snapshots", data=parameters)
 
     @classmethod
     def restore_point(cls, cluster_id_label, s3_location, backup_id, table_names, overwrite=True, automatic=True):

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1561,7 +1561,7 @@ class TestClusterHbaseSnapshot(QdsCliTestCase):
         print_command()
         Connection._api_call = Mock(return_value={})
         qds.main()
-        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshot', {'s3_location':'myString', 'backup_type':'full'})
+        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshots', {'s3_location':'myString', 'backup_type':'full'})
 
     def test_snapshot_with_no_label(self):
         sys.argv = ['qds.py', 'cluster', 'snapshot', '--s3_location', 'myString', '--backup_type', 'full']
@@ -1582,7 +1582,7 @@ class TestClusterHbaseSnapshot(QdsCliTestCase):
         print_command()
         Connection._api_call = Mock(return_value={})
         qds.main()
-        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshot', {'s3_location':'myString'})
+        Connection._api_call.assert_called_with('POST', 'clusters/1234/snapshots', {'s3_location':'myString'})
 
     def test_restore_point(self):
         sys.argv = ['qds.py', 'cluster', 'restore_point', '--label', '1234', '--s3_location', 'myString', '--backup_id', 'abcd', '--table_names', 'tablename']


### PR DESCRIPTION
Changing api to "snapshots" from "snapshot". This is because of a design change. We will show all the snapshots under snapshots/. So collecting all related actions under that namespace. This API is not yet documented or officially supported. So its OK to change.  