### PR TITLE
Command Templates Added

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -11,6 +11,7 @@ from qds_sdk.report import ReportCmdLine
 from qds_sdk.dbtaps import DbTapCmdLine
 from qds_sdk.role import RoleCmdLine
 from qds_sdk.group import GroupCmdLine
+from qds_sdk.command_templates import CommandTemplateCmdLine
 
 import os
 import sys
@@ -404,6 +405,10 @@ def schedulermain(args):
     result = SchedulerCmdLine.run(args)
     print(result)
 
+def commandtemplatesmain(args):
+    result = CommandTemplateCmdLine.run(args)
+    print(result)
+
 def dbtapmain(args):
     result = DbTapCmdLine.run(args)
     print(result)
@@ -500,6 +505,9 @@ def main():
 
     if a0 == "report":
         return reportmain(args)
+
+    if a0 == "commandtemplates":
+        return commandtemplatesmain(args)
 
     if a0 == "dbtap":
         return dbtapmain(args)

--- a/qds_sdk/command_templates.py
+++ b/qds_sdk/command_templates.py
@@ -102,7 +102,7 @@ class CommandTemplateCmdLine:
         try:
             for field in fields:
                 filtered[field] = schedule[field]
-        except KeyError, e:
+        except KeyError as e:
             raise ParseError("Incorrect field name ",CommandTemplateCmdLine.get_list_all_help() )
         return filtered
 

--- a/qds_sdk/command_templates.py
+++ b/qds_sdk/command_templates.py
@@ -1,0 +1,202 @@
+import json
+
+from qds_sdk.qubole import Qubole
+from qds_sdk.resource import Resource
+from argparse import ArgumentParser
+from qds_sdk.commands import *
+from qds_sdk.actions import *
+import argparse
+
+class CommandTemplateCmdLine:
+    list_allparser = None
+    viewparser = None
+    removeparser = None
+    runparser = None
+    run_and_waitparser = None
+    @staticmethod
+    def parsers():
+        argparser = ArgumentParser(prog="qds.py commandtemplates",
+                                        description="Command Templates client for Qubole Data Service.")
+        subparsers = argparser.add_subparsers()
+
+        #list_all command
+        list_all = subparsers.add_parser("list", help="List all available command templates")
+
+        list_all.add_argument("--fields", nargs="*", dest="fields",
+                          help="List of fields to show")
+        list_all.add_argument("--per-page", dest="per_page", type=int, 
+                          help="Number of items per page")
+        list_all.add_argument("--page", dest="page", type=int,
+                          help="Page Number")
+
+        list_all.set_defaults(func=CommandTemplateCmdLine.list_all)
+        CommandTemplateCmdLine.list_allparser = list_all
+
+        #view command
+        view = subparsers.add_parser("view",
+                                     help="View a specific command template")
+        view.add_argument("--id", help="Numeric id of the command template", dest="id", type=int)
+        view.add_argument("--name", help="Name of the command template", dest="name")
+        view.add_argument("--fields", nargs="*", dest="fields",
+                          help="List of fields to show")
+        view.set_defaults(func=CommandTemplateCmdLine.view)
+        CommandTemplateCmdLine.viewparser = view
+
+        #remove command
+        remove = subparsers.add_parser("remove",
+                                     help="Remove a specific command template")
+        remove.add_argument("id", help="Numeric id of the command template", type=int)
+        remove.set_defaults(func=CommandTemplateCmdLine.remove)
+        CommandTemplateCmdLine.removeparser = remove
+        CommandTemplateCmdLine.removeparser = remove
+
+        #run command
+        run = subparsers.add_parser("run", help="Run a command template")
+        run.add_argument("id", help="Numeric id of the command template")
+        run.add_argument("--input_vars",
+            help="Add names and values for input variables", dest="input_vars", nargs="*")
+        run.set_defaults(func=CommandTemplateCmdLine.run_template)
+        CommandTemplateCmdLine.runparser = run
+
+        #run_and_wait command
+        run_and_wait = subparsers.add_parser("run_and_wait", 
+            help="Run a command template and wait for it to complete")
+
+        run_and_wait.add_argument("id", help="Numeric id of the command template")
+        run_and_wait.add_argument("--input_vars", 
+            help="Add name and values of input variables", dest="input_vars", nargs="*")
+
+        run_and_wait.set_defaults(func=CommandTemplateCmdLine.run_and_wait)
+        CommandTemplateCmdLine.run_and_waitparser = run_and_wait
+        return argparser
+
+    @staticmethod
+    def get_list_all_help():
+        return CommandTemplateCmdLine.list_allparser.format_help()
+
+    @staticmethod
+    def get_view_help():
+        return CommandTemplateCmdLine.viewparser.format_help()
+
+    @staticmethod
+    def get_remove_help():
+        return CommandTemplateCmdLine.removeparser.format_help()
+
+    @staticmethod
+    def get_run_help():
+        return CommandTemplateCmdLine.runparser.format_help()
+
+    @staticmethod
+    def get_run_and_wait_help():
+        return CommandTemplateCmdLine.run_and_waitparser.format_help()
+
+    @staticmethod
+    def run(args):
+        parser = CommandTemplateCmdLine.parsers()
+        parsed = parser.parse_args(args)
+        return parsed.func(parsed)
+
+    @staticmethod
+    def filter_fields(schedule, fields):
+        filtered = {}
+        try:
+            for field in fields:
+                filtered[field] = schedule[field]
+        except KeyError, e:
+            raise ParseError("Incorrect field name ",CommandTemplateCmdLine.get_list_all_help() )
+        return filtered
+
+    @staticmethod
+    def list_all(args):
+        commandtemplateslist = CommandTemplate.list_all(args)
+        if args.fields:
+            for s in commandtemplateslist:
+                s.attributes = CommandTemplateCmdLine.filter_fields(s.attributes, args.fields)
+        return json.dumps(commandtemplateslist, default=lambda o: o.attributes, sort_keys=True, indent=4)
+
+    @staticmethod
+    def view(args):
+        if args.id:
+            commandtemplate = CommandTemplate.find(args.id)
+        elif args.name:
+            commandtemplate = CommandTemplate.find_by_name(args.name)
+        else:
+            raise ParseError("Either template id or template name must be specified",CommandTemplateCmdLine.get_view_help() ) 
+        if args.fields:
+            commandtemplate.attributes = CommandTemplateCmdLine.filter_fields(schedule.attributes, args.fields)
+        return json.dumps(commandtemplate.attributes, sort_keys=True, indent=4)
+
+    @staticmethod
+    def remove(args):
+        commandtemplate = CommandTemplate.find(args.id)
+        return json.dumps(commandtemplate.remove(), sort_keys=True, indent=4)
+
+    @staticmethod
+    def run_template(args):
+        commandtemplate = CommandTemplate.find(args.id)
+        return json.dumps(commandtemplate.run_template(args), sort_keys=True, indent=4)
+
+    @staticmethod
+    def run_and_wait(args):
+        commandtemplate = CommandTemplate.find(args.id)
+        cmd = Command.find(commandtemplate.run_template(args)['id'])
+        while not Command.is_done(cmd.status):
+            time.sleep(Qubole.poll_interval)
+            cmd = Command.find(cmd.id)
+
+        if Command.is_success(cmd.status):
+            return cmd.get_results(sys.stdout, delim='\t')
+        else:
+            return "Cannot fetch results - command Id: %s failed with status: %s" % (cmd.id, cmd.status)
+
+
+class CommandTemplate(Resource):
+
+    rest_entity_path = "command_templates"
+    @staticmethod
+    def list_all(args):
+        conn = Qubole.agent()
+        url_path = CommandTemplate.rest_entity_path
+        page_attr = {}
+        if args.page is not None:
+            page_attr["page"] = args.page
+        if args.per_page is not None:
+            page_attr["per_page"] = args.per_page
+        if len(page_attr):
+            myjson = conn.get(url_path, params = page_attr)
+        else:
+            myjson = conn.get(url_path)
+        commandtemplateslist = []
+        for commandtemplate in myjson['command_templates']:
+            commandtemplateslist.append(CommandTemplate(commandtemplate))
+        return commandtemplateslist
+
+    @staticmethod
+    def find_by_name(name):
+        conn = Qubole.agent()
+        if name is not None:
+            # s = "%s?template_name=%s" % (CommandTemplate.rest_entity_path, str(name))
+            result_json = (conn.get(CommandTemplate.rest_entity_path, params={"template_name":name}))
+            # result_json = (conn.get(s))
+            # print result_json["command_templates"][0]
+            if result_json["command_templates"]:
+                return CommandTemplate(result_json["command_templates"][0])
+        return None
+
+    def remove(self):
+        conn = Qubole.agent()
+        remove_url = "%s/remove" % self.element_path(self.id)
+        data = {}
+        return conn.put(remove_url, data)
+
+    def run_template(self, args):
+        conn = Qubole.agent()
+        run_url = "%s/run" % self.element_path(self.id)
+        data = {}
+        if args.input_vars is not None:
+            data['input_vars'] = []
+            for input_var in args.input_vars:
+                a = input_var.split("=")
+                input_var_data = {a[0]:a[1]}
+                data['input_vars'].append(input_var_data)
+        return conn.post(run_url, data)

--- a/qds_sdk/command_templates.py
+++ b/qds_sdk/command_templates.py
@@ -123,7 +123,7 @@ class CommandTemplateCmdLine:
         else:
             raise ParseError("Either template id or template name must be specified",CommandTemplateCmdLine.get_view_help() ) 
         if args.fields:
-            commandtemplate.attributes = CommandTemplateCmdLine.filter_fields(schedule.attributes, args.fields)
+            commandtemplate.attributes = CommandTemplateCmdLine.filter_fields(commandtemplate.attributes, args.fields)
         return json.dumps(commandtemplate.attributes, sort_keys=True, indent=4)
 
     @staticmethod
@@ -175,10 +175,7 @@ class CommandTemplate(Resource):
     def find_by_name(name):
         conn = Qubole.agent()
         if name is not None:
-            # s = "%s?template_name=%s" % (CommandTemplate.rest_entity_path, str(name))
             result_json = (conn.get(CommandTemplate.rest_entity_path, params={"template_name":name}))
-            # result_json = (conn.get(s))
-            # print result_json["command_templates"][0]
             if result_json["command_templates"]:
                 return CommandTemplate(result_json["command_templates"][0])
         return None
@@ -193,8 +190,8 @@ class CommandTemplate(Resource):
         conn = Qubole.agent()
         run_url = "%s/run" % self.element_path(self.id)
         data = {}
+        data['input_vars'] = []
         if args.input_vars is not None:
-            data['input_vars'] = []
             for input_var in args.input_vars:
                 a = input_var.split("=")
                 input_var_data = {a[0]:a[1]}

--- a/tests/test_commandtemplates.py
+++ b/tests/test_commandtemplates.py
@@ -1,0 +1,111 @@
+from __future__ import print_function
+import sys
+import os
+if sys.version_info > (2, 7, 0):
+    import unittest
+else:
+    import unittest2 as unittest
+from mock import *
+import tempfile
+sys.path.append(os.path.join(os.path.dirname(__file__), '../bin'))
+import qds
+import qds_sdk
+from qds_sdk.connection import Connection
+from test_base import print_command
+from test_base import QdsCliTestCase
+from argparse import ArgumentError
+from qds_sdk.exception import *
+def view_templates_side_effect(*args, **kwargs):
+    if args[1] == "command_templates/123":
+      return {'id':'123'}
+    else:
+      return {"actions":[]}
+
+class TestCommandTemplate(QdsCliTestCase):
+
+    def test_view(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'view', '--id', '123']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates/123", params=None)
+
+    def test_view_name(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'view', '--name', 'Show']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': ['123']})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params={'template_name': 'Show'})
+
+    def test_view_no_id_no_name(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'view']
+        print_command()
+        with self.assertRaises(ParseError) as cm:
+            qds.main()
+
+    def test_list(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'list']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': [{'a' : 'b'}]})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params=None)
+
+    def test_list_fields(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'list', '--fields', 'a']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': [{'a' : 'b'}]})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params=None)
+
+    def test_list_per_page(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'list', '--per-page', '1']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': [{'a' : 'b'}]})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params={'per_page': 1})
+
+    def test_list_page_num(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'list', '--page', '1']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': [{'a' : 'b'}]})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params={'page': 1})
+
+    def test_list_page_num_per_page(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'list', '--page', '1', '--per-page', '2']
+        print_command()
+        Connection._api_call = Mock(return_value={'command_templates': [{'a' : 'b'}]})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates", params={'page': 1, 'per_page' : 2})
+
+    # qdd.py commandtemplates view
+    # qds.py commandtemplates view --name
+    # qds.py commandtemplates view --fields
+    # qds.py commandtemplates list
+    # qds.py commandtemplates list --fields
+    # qds.py commandtemplates list --per-page
+    # qds.py commandtemplates list --page
+    # qds.py commandtemplates run ID
+    # qds.py commandtemplates run_and_wait ID
+    # qds.py commandtemplates run_and_wait ID --input_vars
+    def test_remove(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'remove', '123']
+        print_command()
+        Connection._api_call = Mock()
+        Connection._api_call.side_effect = view_templates_side_effect
+        qds.main()
+        Connection._api_call.assert_has_calls([call("GET", "command_templates/123", params=None),
+            call("PUT", "command_templates/123/remove", {})])
+
+    def test_run(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'run', '123',
+         '--input_vars', "table_name='doctors'"]
+        print_command()
+        Connection._api_call = Mock()
+        Connection._api_call.side_effect = view_templates_side_effect
+        qds.main()
+        Connection._api_call.assert_has_calls([call("GET", "command_templates/123", params=None),
+            call("POST", "command_templates/123/run", {'input_vars': [{'table_name':"'doctors'"}]})])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_commandtemplates.py
+++ b/tests/test_commandtemplates.py
@@ -30,6 +30,13 @@ class TestCommandTemplate(QdsCliTestCase):
         qds.main()
         Connection._api_call.assert_called_with("GET", "command_templates/123", params=None)
 
+    def test_view_fields(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'view', '--id', '123', '--fields', 'id']
+        print_command()
+        Connection._api_call = Mock(return_value={'id':'123'})
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "command_templates/123", params=None)
+
     def test_view_name(self):
         sys.argv = ['qds.py', 'commandtemplates', 'view', '--name', 'Show']
         print_command()
@@ -78,16 +85,6 @@ class TestCommandTemplate(QdsCliTestCase):
         qds.main()
         Connection._api_call.assert_called_with("GET", "command_templates", params={'page': 1, 'per_page' : 2})
 
-    # qdd.py commandtemplates view
-    # qds.py commandtemplates view --name
-    # qds.py commandtemplates view --fields
-    # qds.py commandtemplates list
-    # qds.py commandtemplates list --fields
-    # qds.py commandtemplates list --per-page
-    # qds.py commandtemplates list --page
-    # qds.py commandtemplates run ID
-    # qds.py commandtemplates run_and_wait ID
-    # qds.py commandtemplates run_and_wait ID --input_vars
     def test_remove(self):
         sys.argv = ['qds.py', 'commandtemplates', 'remove', '123']
         print_command()
@@ -96,6 +93,13 @@ class TestCommandTemplate(QdsCliTestCase):
         qds.main()
         Connection._api_call.assert_has_calls([call("GET", "command_templates/123", params=None),
             call("PUT", "command_templates/123/remove", {})])
+
+    def test_remove_no_id(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'remove']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
 
     def test_run(self):
         sys.argv = ['qds.py', 'commandtemplates', 'run', '123',
@@ -106,6 +110,20 @@ class TestCommandTemplate(QdsCliTestCase):
         qds.main()
         Connection._api_call.assert_has_calls([call("GET", "command_templates/123", params=None),
             call("POST", "command_templates/123/run", {'input_vars': [{'table_name':"'doctors'"}]})])
+
+    def test_run_no_id(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'run']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
+
+    def test_run_and_wait_no_id(self):
+        sys.argv = ['qds.py', 'commandtemplates', 'run_and_wait']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        with self.assertRaises(SystemExit):
+            qds.main()
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Users can use the options to run existing command templates with desired input variables, list command templates, view a command template or remove a command template. Creating a new command template is still pending, however not many users are likely to use sdk for that feature and can use UI for same.