### PR TITLE
SDK-31: Ensure all our SDKs comply with backoff requirements in our new SLA

### DIFF
--- a/qds_sdk/connection.py
+++ b/qds_sdk/connection.py
@@ -43,20 +43,23 @@ class Connection:
             self.session = requests.Session()
             self.session.mount('https://', MyAdapter())
 
-    @retry((RetryWithDelay, requests.Timeout), tries=6, delay=30, backoff=2)
+    @retry((RetryWithDelay, requests.Timeout), tries=12, delay=1, backoff=2, max_delay=32)
     def get_raw(self, path, params=None):
         return self._api_call_raw("GET", path, params=params)
 
-    @retry((RetryWithDelay, requests.Timeout), tries=6, delay=30, backoff=2)
+    @retry((RetryWithDelay, requests.Timeout), tries=12, delay=1, backoff=2, max_delay=32)
     def get(self, path, params=None):
         return self._api_call("GET", path, params=params)
 
+    @retry((RetryWithDelay, requests.Timeout), tries=12, delay=1, backoff=2, max_delay=32)
     def put(self, path, data=None):
         return self._api_call("PUT", path, data)
 
+    @retry((RetryWithDelay, requests.Timeout), tries=12, delay=1, backoff=2, max_delay=32)
     def post(self, path, data=None):
         return self._api_call("POST", path, data)
 
+    @retry((RetryWithDelay, requests.Timeout), tries=12, delay=1, backoff=2, max_delay=32)
     def delete(self, path, data=None):
         return self._api_call("DELETE", path, data)
 

--- a/qds_sdk/retry.py
+++ b/qds_sdk/retry.py
@@ -5,7 +5,7 @@ from functools import wraps
 log = logging.getLogger("retry")
 
 
-def retry(ExceptionToCheck, tries=4, delay=3, backoff=2):
+def retry(ExceptionToCheck, tries=4, delay=3, backoff=2, max_delay=32):
     def deco_retry(f):
         @wraps(f)
         def f_retry(*args, **kwargs):
@@ -19,6 +19,8 @@ def retry(ExceptionToCheck, tries=4, delay=3, backoff=2):
                     time.sleep(mdelay)
                     mtries -= 1
                     mdelay *= backoff
+                    if (mdelay >= max_delay):
+                        mdelay = max_delay
             return f(*args, **kwargs)
         return f_retry  # true decorator
     return deco_retry


### PR DESCRIPTION
our SLA document will now have the following clause:

"Back-off Requirements" means, when an error occurs, the Application is responsible
waiting for a period of time before issuing another request. This means that after the first 
error, there is a minimum back-off interval of 1 second and for each consecutive error, the
back-off interval increases exponentially (by a factor of 2) up to 32 seconds.

we have to make sure that all our SDKs are in compliance. The errors in question here are all 5xx error codes.