### PR TITLE
fixes #143 in qubole/qds-sdk-py

### DIFF
--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -1047,18 +1047,18 @@ class ClusterInfoV13():
         self.disallow_cluster_termination = disallow_cluster_termination
         self.enable_ganglia_monitoring = enable_ganglia_monitoring
         self.node_bootstrap_file = node_bootstrap_file
-        self.__set_node_configuration(master_instance_type, slave_instance_type, initial_nodes, max_nodes, slave_request_type, fallback_to_ondemand)
-        self.__set_ec2_settings(aws_access_key_id, aws_secret_access_key, aws_region, aws_availability_zone, vpc_id, subnet_id,
+        self.set_node_configuration(master_instance_type, slave_instance_type, initial_nodes, max_nodes, slave_request_type, fallback_to_ondemand)
+        self.set_ec2_settings(aws_access_key_id, aws_secret_access_key, aws_region, aws_availability_zone, vpc_id, subnet_id,
                                 bastion_node_public_dns, role_instance_profile)
-        self.__set_hadoop_settings(custom_config, use_hbase, custom_ec2_tags, use_hadoop2, use_spark, use_qubole_placement_policy)
-        self.__set_spot_instance_settings(maximum_bid_price_percentage, timeout_for_request, maximum_spot_instance_percentage)
-        self.__set_stable_spot_instance_settings(stable_maximum_bid_price_percentage, stable_timeout_for_request, stable_allow_fallback)
-        self.__set_ebs_volume_settings(ebs_volume_count, ebs_volume_type, ebs_volume_size)
-        self.__set_fairscheduler_settings(fairscheduler_config_xml, default_pool)
-        self.__set_security_settings(encrypted_ephemerals, ssh_public_key, persistent_security_group)
-        self.__set_presto_settings(enable_presto, presto_custom_config)
+        self.set_hadoop_settings(custom_config, use_hbase, custom_ec2_tags, use_hadoop2, use_spark, use_qubole_placement_policy)
+        self.set_spot_instance_settings(maximum_bid_price_percentage, timeout_for_request, maximum_spot_instance_percentage)
+        self.set_stable_spot_instance_settings(stable_maximum_bid_price_percentage, stable_timeout_for_request, stable_allow_fallback)
+        self.set_ebs_volume_settings(ebs_volume_count, ebs_volume_type, ebs_volume_size)
+        self.set_fairscheduler_settings(fairscheduler_config_xml, default_pool)
+        self.set_security_settings(encrypted_ephemerals, ssh_public_key, persistent_security_group)
+        self.set_presto_settings(enable_presto, presto_custom_config)
 
-    def __set_ec2_settings(self,
+    def set_ec2_settings(self,
                            aws_access_key_id=None,
                            aws_secret_access_key=None,
                            aws_region=None,
@@ -1076,7 +1076,7 @@ class ClusterInfoV13():
         self.ec2_settings['bastion_node_public_dns'] = bastion_node_public_dns
         self.ec2_settings['role_instance_profile'] = role_instance_profile
 
-    def __set_node_configuration(self, master_instance_type=None,
+    def set_node_configuration(self, master_instance_type=None,
                             slave_instance_type=None,
                             initial_nodes=None,
                             max_nodes=None,
@@ -1089,7 +1089,7 @@ class ClusterInfoV13():
         self.node_configuration['slave_request_type'] = slave_request_type
         self.node_configuration['fallback_to_ondemand'] = fallback_to_ondemand
 
-    def __set_hadoop_settings(self, custom_config=None,
+    def set_hadoop_settings(self, custom_config=None,
                             use_hbase=None,
                             custom_ec2_tags=None,
                             use_hadoop2=None,
@@ -1107,7 +1107,7 @@ class ClusterInfoV13():
             except Exception as e:
                 raise Exception("Invalid JSON string for custom ec2 tags: %s" % e.message)
 
-    def __set_spot_instance_settings(self, maximum_bid_price_percentage=None,
+    def set_spot_instance_settings(self, maximum_bid_price_percentage=None,
                                    timeout_for_request=None,
                                    maximum_spot_instance_percentage=None):
         self.node_configuration['spot_instance_settings'] = {
@@ -1115,7 +1115,7 @@ class ClusterInfoV13():
                'timeout_for_request': timeout_for_request,
                'maximum_spot_instance_percentage': maximum_spot_instance_percentage}
 
-    def __set_stable_spot_instance_settings(self, maximum_bid_price_percentage=None,
+    def set_stable_spot_instance_settings(self, maximum_bid_price_percentage=None,
                                           timeout_for_request=None,
                                           allow_fallback=True):
         self.node_configuration['stable_spot_instance_settings'] = {
@@ -1123,7 +1123,7 @@ class ClusterInfoV13():
                'timeout_for_request': timeout_for_request,
                'allow_fallback': allow_fallback}
 
-    def __set_ebs_volume_settings(self, ebs_volume_count=None,
+    def set_ebs_volume_settings(self, ebs_volume_count=None,
                                  ebs_volume_type=None,
                                  ebs_volume_size=None):
       self.node_configuration['ebs_volume_count'] = ebs_volume_count
@@ -1131,13 +1131,13 @@ class ClusterInfoV13():
       self.node_configuration['ebs_volume_size'] = ebs_volume_size
 
 
-    def __set_fairscheduler_settings(self, fairscheduler_config_xml=None,
+    def set_fairscheduler_settings(self, fairscheduler_config_xml=None,
                                    default_pool=None):
         self.hadoop_settings['fairscheduler_settings'] = {
                'fairscheduler_config_xml': fairscheduler_config_xml,
                'default_pool': default_pool}
 
-    def __set_security_settings(self,
+    def set_security_settings(self,
                               encrypted_ephemerals=None,
                               ssh_public_key=None,
                               persistent_security_group=None):
@@ -1145,7 +1145,7 @@ class ClusterInfoV13():
         self.security_settings['ssh_public_key'] = ssh_public_key
         self.security_settings['persistent_security_group'] = persistent_security_group
 
-    def __set_presto_settings(self, enable_presto=None, presto_custom_config=None):
+    def set_presto_settings(self, enable_presto=None, presto_custom_config=None):
         self.presto_settings['enable_presto'] = enable_presto
         self.presto_settings['custom_config'] = presto_custom_config
 


### PR DESCRIPTION
double underscored names are mangled by python as they are seen as
private fields. this is not suitable when importing the sdk and writing
factories for various qubole resources as there is no easy way to update
specific parts of the cluster info object.