### PR TITLE
SDK-149: adding output table format support for dbimport

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -957,8 +957,6 @@ class DbExportCommand(Command):
                          help="Can be 1 for Hive export or 2 for HDFS/S3 export")
     optparser.add_option("--hive_table", dest="hive_table",
                          help="Mode 1: Name of the Hive Table from which data will be exported")
-    optparser.add_option("--hive_serde", dest="hive_serde",
-                         help="Output format of the Hive Table")
     optparser.add_option("--partition_spec", dest="partition_spec",
                          help="Mode 1: (optional) Partition specification for Hive table")
     optparser.add_option("--dbtap_id", dest="dbtap_id",
@@ -1067,6 +1065,8 @@ class DbImportCommand(Command):
                          help="Can be 1 for Hive export or 2 for HDFS/S3 export")
     optparser.add_option("--hive_table", dest="hive_table",
                          help="Mode 1: Name of the Hive Table from which data will be exported")
+    optparser.add_option("--hive_serde", dest="hive_serde",
+                         help="Output format of the Hive Table")
     optparser.add_option("--dbtap_id", dest="dbtap_id",
                          help="Modes 1 and 2: DbTap Id of the target database in Qubole")
     optparser.add_option("--db_table", dest="db_table",

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -957,6 +957,8 @@ class DbExportCommand(Command):
                          help="Can be 1 for Hive export or 2 for HDFS/S3 export")
     optparser.add_option("--hive_table", dest="hive_table",
                          help="Mode 1: Name of the Hive Table from which data will be exported")
+    optparser.add_option("--hive_serde", dest="hive_serde",
+                         help="Output format of the Hive Table")
     optparser.add_option("--partition_spec", dest="partition_spec",
                          help="Mode 1: (optional) Partition specification for Hive table")
     optparser.add_option("--dbtap_id", dest="dbtap_id",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1280,6 +1280,7 @@ class TestDbImportCommand(QdsCliTestCase):
                  'db_split_column': None,
                  'can_notify': False,
                  'hive_table': 'myhivetable',
+                 'hive_serde': None,
                  'db_table': 'mydbtable',
                  'db_extract_query': None,
                  'retry': 2})

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1285,6 +1285,29 @@ class TestDbImportCommand(QdsCliTestCase):
                  'db_extract_query': None,
                  'retry': 2})
 
+    def test_submit_command_with_hive_serde(self):
+        sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+         '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--hive_serde', 'orc', '--retry', 2]
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'db_parallelism': None,
+                 'name': None,
+                 'dbtap_id': '1',
+                 'db_where': None,
+                 'db_boundary_query': None,
+                 'mode': '1',
+                 'tags': None,
+                 'command_type': 'DbImportCommand',
+                 'db_split_column': None,
+                 'can_notify': False,
+                 'hive_table': 'myhivetable',
+                 'hive_serde': 'orc',
+                 'db_table': 'mydbtable',
+                 'db_extract_query': None,
+                 'retry': 2})
+
     def test_retry_out_of_range(self):
         sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
          '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 6]


### PR DESCRIPTION
Added support for hive_serde for dbimport command. It can be passed using the --hive_serde option.
