### PR TITLE
new: dev: SDK-135: Add support for running DB Import/Export command on Customer Cluster

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -993,6 +993,8 @@ class DbExportCommand(Command):
     optparser.add_option("--print-logs-live", action="store_true", dest="print_logs_live",
                          default=False, help="Fetch logs and print them to stderr while command is running.")
     optparser.add_option("--retry", dest="retry", default=0, choices=[1,2,3], help="Number of retries for a job")
+    optparser.add_option("--use_customer_cluster", dest="use_customer_cluster", default="false", choices=["true", "false"], help="To Run query on specific customer cluster.")
+    optparser.add_option("--customer_cluster_label", dest="customer_cluster_label", help="The label of the Hadoop 1 or Hadoop 2 cluster on which you want to run query.")
 
     @classmethod
     def parse(cls, args):
@@ -1096,6 +1098,8 @@ class DbImportCommand(Command):
     optparser.add_option("--print-logs-live", action="store_true", dest="print_logs_live",
                          default=False, help="Fetch logs and print them to stderr while command is running.")
     optparser.add_option("--retry", dest="retry", default=0, choices=[1,2,3], help="Number of retries for a job")
+    optparser.add_option("--use_customer_cluster", dest="use_customer_cluster", default="false", choices=["true", "false"], help="To Run query on specific customer cluster.")
+    optparser.add_option("--customer_cluster_label", dest="customer_cluster_label", help="The label of the Hadoop 1 or Hadoop 2 cluster on which you want to run query.")
 
     @classmethod
     def parse(cls, args):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="qds_sdk",
-    version="unreleased",
+    version="1.9.1",
     author="Qubole",
     author_email="dev@qubole.com",
     description=("Python SDK for coding to the Qubole Data Service API"),

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(fname):
 
 setup(
     name="qds_sdk",
-    version="1.9.3",
+    version="1.9.4",
     author="Qubole",
     author_email="dev@qubole.com",
     description=("Python SDK for coding to the Qubole Data Service API"),

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1152,7 +1152,34 @@ class TestDbExportCommand(QdsCliTestCase):
                  'dbtap_id': '1',
                  'can_notify': False,
                  'db_update_mode': None,
-                 'retry': 3})
+                 'retry': 3,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
+
+    def test_submit_command_on_cluster(self):
+        sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+         '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 3,
+         '--use_customer_cluster','true','--customer_cluster_label', 'hadoop2']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'export_dir': None,
+                 'name': None,
+                 'db_update_keys': None,
+                 'partition_spec': None,
+                 'fields_terminated_by': None,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable',
+                 'mode': '1',
+                 'tags': None,
+                 'command_type': 'DbExportCommand',
+                 'dbtap_id': '1',
+                 'can_notify': False,
+                 'db_update_mode': None,
+                 'retry': 3,
+                 'use_customer_cluster': 'true',
+                 'customer_cluster_label': 'hadoop2'})
 
     def test_submit_fail_with_no_parameters(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit']
@@ -1180,7 +1207,9 @@ class TestDbExportCommand(QdsCliTestCase):
                  'dbtap_id': '1',
                  'can_notify': True,
                  'db_update_mode': None,
-                 'retry': 0})
+                 'retry': 0,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
 
     def test_submit_with_name(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
@@ -1202,7 +1231,9 @@ class TestDbExportCommand(QdsCliTestCase):
                  'dbtap_id': '1',
                  'can_notify': False,
                  'db_update_mode': None,
-                 'retry': 0})
+                 'retry': 0,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
 
     def test_submit_with_update_mode_and_keys(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
@@ -1225,7 +1256,9 @@ class TestDbExportCommand(QdsCliTestCase):
                  'dbtap_id': '1',
                  'can_notify': False,
                  'db_update_mode': 'updateonly',
-                 'retry': 0})
+                 'retry': 0,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
 
     def test_submit_with_mode_2(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '2', '--dbtap_id', '1',
@@ -1248,7 +1281,9 @@ class TestDbExportCommand(QdsCliTestCase):
                  'dbtap_id': '1',
                  'can_notify': False,
                  'db_update_mode': None,
-                 'retry': 0})
+                 'retry': 0,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
 
     def test_retry_out_of_range(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
@@ -1282,7 +1317,34 @@ class TestDbImportCommand(QdsCliTestCase):
                  'hive_table': 'myhivetable',
                  'db_table': 'mydbtable',
                  'db_extract_query': None,
-                 'retry': 2})
+                 'retry': 2,
+                 'use_customer_cluster': 'false',
+                 'customer_cluster_label': None})
+
+    def test_submit_command_on_cluster(self):
+        sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+         '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 2,
+         '--use_customer_cluster','true','--customer_cluster_label', 'hadoop2']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'db_parallelism': None,
+                 'name': None,
+                 'dbtap_id': '1',
+                 'db_where': None,
+                 'db_boundary_query': None,
+                 'mode': '1',
+                 'tags': None,
+                 'command_type': 'DbImportCommand',
+                 'db_split_column': None,
+                 'can_notify': False,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable',
+                 'db_extract_query': None,
+                 'retry': 2,
+                 'use_customer_cluster': 'true',
+                 'customer_cluster_label':'hadoop2'})
 
     def test_retry_out_of_range(self):
         sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',


### PR DESCRIPTION
* added two new fields: 1. use_customer_cluster, 2. customer_cluster_label to both DbImport/Export Command Type.

* Unit tests for the same