### PR TITLE
SDK-155: Add notebook API related changes to Spark Command

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -427,7 +427,7 @@ class SqlCommand(Command):
 class SparkCommand(Command):
 
     usage = ("sparkcmd <submit|run> [options]")
-    allowedlanglist = ["python", "scala","R", "notebook"]
+    allowedlanglist = ["python", "scala","R"]
 
     optparser = GentleOptionParser(usage=usage)
     optparser.add_option("--program", dest="program",help=SUPPRESS_HELP)

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -427,7 +427,7 @@ class SqlCommand(Command):
 class SparkCommand(Command):
 
     usage = ("sparkcmd <submit|run> [options]")
-    allowedlanglist = ["python", "scala","R"]
+    allowedlanglist = ["python", "scala","R", "notebook"]
 
     optparser = GentleOptionParser(usage=usage)
     optparser.add_option("--program", dest="program",help=SUPPRESS_HELP)
@@ -435,6 +435,8 @@ class SparkCommand(Command):
     optparser.add_option("--cmdline", dest="cmdline", help="command line for Spark")
 
     optparser.add_option("--sql", dest="sql", help="sql for Spark")
+
+    optparser.add_option("--note-id", dest="note_id", help="Id of the Notebook to run.")
 
     optparser.add_option("-f", "--script_location", dest="script_location",
                          help="Path where spark program to run is stored. Has to be a local file path")
@@ -468,12 +470,12 @@ class SparkCommand(Command):
     @classmethod
     def validate_program(cls, options):
         bool_program = options.program is not None
-        bool_other_options = options.script_location is not None or options.cmdline is not None or options.sql is not None
+        bool_other_options = options.script_location is not None or options.cmdline is not None or options.sql is not None or options.note_id is not None
 
         # if both are false then no option is specified ==> raise ParseError
         # if both are true then atleast two option specified ==> raise ParseError
         if bool_program == bool_other_options:
-            raise ParseError("Exactly One of script location or program or cmdline or sql should be specified", cls.optparser.format_help())
+            raise ParseError("Exactly One of script location or program or cmdline or sql or note_id should be specified", cls.optparser.format_help())
         if bool_program:
             if options.language is None:
                 raise ParseError("Unspecified language for Program", cls.optparser.format_help())
@@ -481,12 +483,12 @@ class SparkCommand(Command):
     @classmethod
     def validate_cmdline(cls, options):
         bool_cmdline = options.cmdline is not None
-        bool_other_options = options.script_location is not None or options.program is not None or options.sql is not None
+        bool_other_options = options.script_location is not None or options.program is not None or options.sql is not None or options.note_id is not None
 
         # if both are false then no option is specified ==> raise ParseError
         # if both are true then atleast two option specified ==> raise ParseError
         if bool_cmdline == bool_other_options:
-            raise ParseError("Exactly One of script location or program or cmdline or sql should be specified", cls.optparser.format_help())
+            raise ParseError("Exactly One of script location or program or cmdline or sql or note_id should be specified", cls.optparser.format_help())
         if bool_cmdline:
             if options.language is not None:
                 raise ParseError("Language cannot be specified with the commandline option", cls.optparser.format_help())
@@ -496,12 +498,12 @@ class SparkCommand(Command):
     @classmethod
     def validate_sql(cls, options):
         bool_sql = options.sql is not None
-        bool_other_options = options.script_location is not None or options.program is not None or options.cmdline is not None
+        bool_other_options = options.script_location is not None or options.program is not None or options.cmdline is not None or options.note_id is not None
 
         # if both are false then no option is specified => raise PraseError
         # if both are true then atleast two option specified => raise ParseError
         if bool_sql == bool_other_options:
-            raise ParseError("Exactly One of script location or program or cmdline or sql should be specified", cls.optparser.format_help())
+            raise ParseError("Exactly One of script location or program or cmdline or sql or note_id should be specified", cls.optparser.format_help())
         if bool_sql:
             if options.language is not None:
                 raise ParseError("Language cannot be specified with the 'sql' option", cls.optparser.format_help())
@@ -509,12 +511,12 @@ class SparkCommand(Command):
     @classmethod
     def validate_script_location(cls, options):
         bool_script_location = options.script_location is not None
-        bool_other_options = options.program is not None or options.cmdline is not None or options.sql is not None
+        bool_other_options = options.program is not None or options.cmdline is not None or options.sql is not None or options.note_id is not None
 
         # if both are false then no option is specified ==> raise ParseError
         # if both are true then atleast two option specified ==> raise ParseError
         if bool_script_location == bool_other_options:
-            raise ParseError("Exactly One of script location or program or cmdline or sql should be specified", cls.optparser.format_help())
+            raise ParseError("Exactly One of script location or program or cmdline or sql or note_id should be specified", cls.optparser.format_help())
 
         if bool_script_location:
             if options.language is not None:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -390,7 +390,42 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
+
+    def test_submit_notebook(self):
+        sys.argv = ['qds.py', 'sparkcmd', 'submit', '--note-id', '111','--name', 'notebook-cmd']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'macros': None,
+                 'label': None,
+                 'language': None,
+                 'tags': None,
+                 'name': 'notebook-cmd',
+                 'sql': None,
+                 'program': None,
+                 'app_id': None,
+                 'cmdline':None,
+                 'command_type': 'SparkCommand',
+                 'arguments': None,
+                 'user_program_arguments': None,
+                 'can_notify': False,
+                 'script_location': None,
+                 'note_id' : '111',
+                 'retry': 0})
+
+    def test_submit_notebook_with_cmdline(self):
+        sys.argv = ['qds.py', 'sparkcmd', 'submit', '--note-id', '111', '--cmdline', 'ls']
+        print_command()
+        with self.assertRaises(qds_sdk.exception.ParseError):
+            qds.main()
+    def test_submit_notebook_with_program(self):
+        sys.argv = ['qds.py', 'sparkcmd', 'submit', '--note-id', '111', '--program', 'print "hello"']
+        print_command()
+        with self.assertRaises(qds_sdk.exception.ParseError):
+            qds.main()
 
     def test_submit_script_location_aws(self):
         sys.argv = ['qds.py', 'sparkcmd', 'submit', '--script_location', 's3://bucket/path-to-script']
@@ -421,6 +456,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_script_location_local_scala(self):
@@ -446,6 +482,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_script_location_local_java(self):
@@ -480,6 +517,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_script_location_local_sql(self):
@@ -505,6 +543,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_sql(self):
@@ -527,6 +566,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_sql_with_language(self):
@@ -589,6 +629,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'cmdline': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_tags(self):
@@ -612,6 +653,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'cmdline': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_cluster_label(self):
@@ -635,6 +677,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'command_type': 'SparkCommand',
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_name(self):
@@ -658,6 +701,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'command_type': 'SparkCommand',
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_notify(self):
@@ -681,6 +725,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': True,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_python_program(self):
@@ -703,6 +748,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_user_program_arguments(self):
@@ -728,6 +774,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': 'world',
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_scala_program(self):
@@ -750,6 +797,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_R_program(self):
@@ -772,6 +820,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_program_to_app(self):
@@ -795,6 +844,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_sql_to_app(self):
@@ -818,6 +868,7 @@ class TestSparkCommand(QdsCliTestCase):
                  'user_program_arguments': None,
                  'can_notify': False,
                  'script_location': None,
+                 'note_id' : None,
                  'retry': 0})
 
     def test_submit_script_location_local_py_to_app(self):
@@ -844,6 +895,7 @@ class TestSparkCommand(QdsCliTestCase):
                      'user_program_arguments': None,
                      'can_notify': False,
                      'script_location': None,
+                     'note_id' : None,
                      'retry': 0})
 
     def test_submit_cmdline_to_app(self):


### PR DESCRIPTION
The PR contains the changes to Support `note_id`  - a new params as part of Spark Command.
With this, we will be able to Run a Notebook from SDK programatically.

All the existing things remain same. 
Unit tests for the same are added.