### PR TITLE
Changed protocol version of SSL to work with changed ssl ciphers on ELB

### DIFF
--- a/qds_sdk/connection.py
+++ b/qds_sdk/connection.py
@@ -26,7 +26,7 @@ class MyAdapter(HTTPAdapter):
         self.poolmanager = PoolManager(num_pools=connections,
                                        maxsize=maxsize,
                                        block=block,
-                                       ssl_version=ssl.PROTOCOL_TLSv1)
+                                       ssl_version=ssl.PROTOCOL_SSLv23)
 
 
 class Connection:


### PR DESCRIPTION
With new SSL certs TSLv1 protocol was failing during handshake with following error:
ConnectionError: ('Connection aborted.', error(54, 'Connection reset by peer'))

PROTOCOL_SSLv23 works well with the new SSL certs and is backward compatible.

Tested this with "api.qubole.com" as well. Works fine.