### PR TITLE
SDK-219 : DBExport command does not have option to pass Customercluster option

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -977,6 +977,10 @@ class DbExportCommand(Command):
                          help="Modes 1 and 2: DbTap Id of the target database in Qubole")
     optparser.add_option("--db_table", dest="db_table",
                          help="Modes 1 and 2: Table to export to in the target database")
+    optparser.add_option("--use_customer_cluster", dest="use_customer_cluster", default=False,
+                         help="Modes 1 and 2: To use cluster to run command ")
+    optparser.add_option("--customer_cluster_label", dest="customer_cluster_label",
+                         help="Modes 1 and 2: the label of the cluster to run the command on")
     optparser.add_option("--db_update_mode", dest="db_update_mode",
                          help="Modes 1 and 2: (optional) can be 'allowinsert' or "
                               "'updateonly'. If updateonly is "
@@ -1085,6 +1089,10 @@ class DbImportCommand(Command):
                          help="Modes 1 and 2: DbTap Id of the target database in Qubole")
     optparser.add_option("--db_table", dest="db_table",
                          help="Modes 1 and 2: Table to export to in the target database")
+    optparser.add_option("--use_customer_cluster", dest="use_customer_cluster", default=False,
+                         help="Modes 1 and 2: To use cluster to run command ")
+    optparser.add_option("--customer_cluster_label", dest="customer_cluster_label",
+                         help="Modes 1 and 2: the label of the cluster to run the command on")
     optparser.add_option("--where_clause", dest="db_where",
                          help="Mode 1: where clause to be applied to the table before extracting rows to be imported")
     optparser.add_option("--parallelism", dest="db_parallelism",

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1291,7 +1291,9 @@ class TestDbExportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'export_dir': None,
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'export_dir': None,
                  'name': None,
                  'db_update_keys': None,
                  'partition_spec': None,
@@ -1319,7 +1321,9 @@ class TestDbExportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'export_dir': None,
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'export_dir': None,
                  'name': None,
                  'db_update_keys': None,
                  'partition_spec': None,
@@ -1334,6 +1338,30 @@ class TestDbExportCommand(QdsCliTestCase):
                  'db_update_mode': None,
                  'retry': 0})
 
+    def test_use_customer_cluster_command(self):
+        sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+         '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 3,'--use_customer_cluster',True,'--customer_cluster_label','hadoop1']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'customer_cluster_label': 'hadoop1',
+                 'use_customer_cluster': True,
+                 'export_dir': None,
+                 'name': None,
+                 'db_update_keys': None,
+                 'partition_spec': None,
+                 'fields_terminated_by': None,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable',
+                 'mode': '1',
+                 'tags': None,
+                 'command_type': 'DbExportCommand',
+                 'dbtap_id': '1',
+                 'can_notify': False,
+                 'db_update_mode': None,
+                 'retry': 3})
+
     def test_submit_with_name(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
          '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--name', 'commandname']
@@ -1341,7 +1369,9 @@ class TestDbExportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'export_dir': None,
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'export_dir': None,
                  'name': 'commandname',
                  'db_update_keys': None,
                  'partition_spec': None,
@@ -1364,7 +1394,9 @@ class TestDbExportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'export_dir': None,
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'export_dir': None,
                  'name': None,
                  'db_update_keys': 'key1',
                  'partition_spec': None,
@@ -1387,7 +1419,9 @@ class TestDbExportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'export_dir': 's3:///export-path/',
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'export_dir': 's3:///export-path/',
                  'name': None,
                  'db_update_keys': None,
                  'partition_spec': None,
@@ -1421,7 +1455,9 @@ class TestDbImportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'db_parallelism': None,
+               { 'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'db_parallelism': None,
                  'name': None,
                  'dbtap_id': '1',
                  'db_where': None,
@@ -1437,6 +1473,33 @@ class TestDbImportCommand(QdsCliTestCase):
                  'db_extract_query': None,
                  'retry': 2})
 
+    def test_use_customer_cluster_command(self):
+        sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+                    '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 3, '--use_customer_cluster',
+                    True, '--customer_cluster_label', 'hadoop2']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'customer_cluster_label': 'hadoop2',
+                 'use_customer_cluster': True,
+                 'db_parallelism': None,
+                 'name': None,
+                 'hive_serde': None,
+                 'tags': None,
+                 'db_where': None,
+                 'mode': '1',
+                 'db_boundary_query': None,
+                 'db_extract_query': None,
+                 'db_split_column': None,
+                 'retry': 3,
+                 'command_type': 'DbImportCommand',
+                 'dbtap_id': '1',
+                 'can_notify': False,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable'
+                 })
+
     def test_submit_command_with_hive_serde(self):
         sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
          '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--hive_serde', 'orc', '--retry', 2]
@@ -1444,7 +1507,9 @@ class TestDbImportCommand(QdsCliTestCase):
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
         Connection._api_call.assert_called_with('POST', 'commands',
-                {'db_parallelism': None,
+                {'customer_cluster_label': None,
+                 'use_customer_cluster': False,
+                 'db_parallelism': None,
                  'name': None,
                  'dbtap_id': '1',
                  'db_where': None,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1362,6 +1362,30 @@ class TestDbExportCommand(QdsCliTestCase):
                  'db_update_mode': None,
                  'retry': 3})
 
+    def test_use_customer_cluster_command_set_false(self):
+        sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+         '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 3,'--use_customer_cluster',False,'--customer_cluster_label','hadoop1']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'customer_cluster_label': 'hadoop1',
+                 'use_customer_cluster': False,
+                 'export_dir': None,
+                 'name': None,
+                 'db_update_keys': None,
+                 'partition_spec': None,
+                 'fields_terminated_by': None,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable',
+                 'mode': '1',
+                 'tags': None,
+                 'command_type': 'DbExportCommand',
+                 'dbtap_id': '1',
+                 'can_notify': False,
+                 'db_update_mode': None,
+                 'retry': 3})
+
     def test_submit_with_name(self):
         sys.argv = ['qds.py', 'dbexportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
          '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--name', 'commandname']
@@ -1483,6 +1507,33 @@ class TestDbImportCommand(QdsCliTestCase):
         Connection._api_call.assert_called_with('POST', 'commands',
                 {'customer_cluster_label': 'hadoop2',
                  'use_customer_cluster': True,
+                 'db_parallelism': None,
+                 'name': None,
+                 'hive_serde': None,
+                 'tags': None,
+                 'db_where': None,
+                 'mode': '1',
+                 'db_boundary_query': None,
+                 'db_extract_query': None,
+                 'db_split_column': None,
+                 'retry': 3,
+                 'command_type': 'DbImportCommand',
+                 'dbtap_id': '1',
+                 'can_notify': False,
+                 'hive_table': 'myhivetable',
+                 'db_table': 'mydbtable'
+                 })
+
+    def test_use_customer_cluster_command_set_false(self):
+        sys.argv = ['qds.py', 'dbimportcmd', 'submit', '--mode', '1', '--dbtap_id', '1',
+                    '--db_table', 'mydbtable', '--hive_table', 'myhivetable', '--retry', 3, '--use_customer_cluster',
+                    False, '--customer_cluster_label', 'hadoop2']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'customer_cluster_label': 'hadoop2',
+                 'use_customer_cluster': False,
                  'db_parallelism': None,
                  'name': None,
                  'hive_serde': None,


### PR DESCRIPTION
Added 'use_customer_cluster' and 'customer_cluster_label' options to DBExport and DBImport commands. Added the corresponding unit tests.