### PR TITLE
Add exception instead of "pass" to avoid silently skipping of write

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1261,8 +1261,7 @@ def _read_iteratively(key_instance, fp, delim):
                 elif isinstance(fp, io.BufferedIOBase) or isinstance(fp, io.RawIOBase):
                     fp.write(data.decode('utf8').replace(chr(1), delim).encode('utf8'))
                 else:
-                    # Can this happen? Don't know what's the right thing to do in this case.
-                    pass
+                    raise ValueError('Only subclasses of io.TextIOBase or io.BufferedIOBase supported')
         except StopIteration:
             # Stream closes itself when the exception is raised
             return


### PR DESCRIPTION
I have faced an issue when passing NamedTemporaryFile instance to get_results().
It silently skipped writing, which is very bad.
So to avoid this, commentary 'Can this happen? Don't know what's the right thing to do in this case.' and 'pass' should be replaced with 'raise ValueError()'.