### PR TITLE
Use OrdinaryCallingFormat for boto s3 connections.

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -237,7 +237,8 @@ class Command(Resource):
                 storage_credentials = conn.get(Account.credentials_rest_entity_path)
                 boto_conn = boto.connect_s3(aws_access_key_id=storage_credentials['storage_access_key'],
                                             aws_secret_access_key=storage_credentials['storage_secret_key'],
-                                            security_token = storage_credentials['session_token'])
+                                            security_token=storage_credentials['session_token'],
+                                            calling_format='boto.s3.connection.OrdinaryCallingFormat')
 
                 log.info("Starting download from result locations: [%s]" % ",".join(r['result_location']))
                 #fetch latest value of num_result_dir


### PR DESCRIPTION
For S3 buckets with dots in them (eg qubole.customer_name), boto cannot verify ssl certs and downloading data from S3 fails. The work-around is to use OrdinaryCallingFormat (rather than SubdomainCallingFormat), which puts the bucket name in the url rather than the domain.

More info in: https://github.com/boto/boto/issues/2836