### PR TITLE
fixes #175. utf-8 errors in Python 3. 

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1237,9 +1237,9 @@ def _read_iteratively(key_instance, fp, delim):
             else:
                 import io
                 if isinstance(fp, io.TextIOBase):
-                    fp.buffer.write(data.decode('utf-8').replace(chr(1), delim).encode('utf8'))
+                    fp.buffer.write(data.replace(bytes([1]), delim.encode('utf8')))
                 elif isinstance(fp, io.BufferedIOBase) or isinstance(fp, io.RawIOBase):
-                    fp.write(data.decode('utf8').replace(chr(1), delim).encode('utf8'))
+                    fp.write(data.replace(bytes([1]), delim.encode('utf8')))
                 else:
                     # Can this happen? Don't know what's the right thing to do in this case.
                     pass


### PR DESCRIPTION
Caused by block reads chopping multibyte utf-8 sequences in half

Because of the 8192 bytes read block size, a utf-8 character can possibly be cut in two, causing the block to be invalid utf-8.

Fixed by not decoding the block. Instead encode the delimiter and do the replace operation with bytes instead of str.