### PR TITLE
Sdk 238 - Python SDK: delete command template failing with 404 Not Found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tags
 
 # Idea IDE
 .idea
+
+#scratch directory
+./scratch/*

--- a/qds_sdk/template.py
+++ b/qds_sdk/template.py
@@ -62,7 +62,12 @@ class TemplateCmdLine:
         submit.add_argument("--id", dest="id", required=True, help="Id of the template to Submit")
         submit.add_argument("--j", dest="data", required=True, help="Path to JSON file or json string with input field details")
         submit.set_defaults(func=TemplateCmdLine.submit)
-        
+
+        #delete
+        delete = subparsers.add_parser("delete",help="Delete a template using the template id")
+        delete.add_argument("--id",dest='id',required=True,help="id of the template to be deleted")
+        delete.set_defaults(func=TemplateCmdLine.delete)
+
         return argparser
         
     @staticmethod
@@ -109,7 +114,11 @@ class TemplateCmdLine:
     
     @staticmethod
     def list(args):
-        return Template.listTemplates(args)    
+        return Template.listTemplates(args)
+
+    @staticmethod
+    def delete(args):
+        Template.deleteTemplate(args.id)
     
 def getSpec(args):
     if args.data is not None:
@@ -255,7 +264,7 @@ class Template(Resource):
     def listTemplates(args):
         """
         Fetch existing Templates details.
-        
+
         Args:
             `args`: dictionary containing the value of page number and per-page value
         Returns:
@@ -272,3 +281,9 @@ class Template(Resource):
             url_path = "%s?%s" % (url_path, "&".join(page_attr))
 
         return conn.get(url_path)
+
+    @staticmethod
+    def deleteTemplate(id):
+        path = Template.element_path(id) + "/remove"
+        conn = Qubole.agent()
+        conn.put(path)

--- a/tests/test_template.py
+++ b/tests/test_template.py
@@ -28,13 +28,13 @@ class TestTemplateCheck(QdsCliTestCase):
         with open(file_path) as f:
             data = json.load(f)
         Connection._api_call.assert_called_with("POST", "command_templates", data)
-    
+
     def test_create_template_without_data(self):
         sys.argv = ['qds.py', 'template', 'create']
         print_command()
         with self.assertRaises(SystemExit):
             qds.main()
-    
+
     def test_edit_template(self):
         file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'input_edit_template.json')
         sys.argv = ['qds.py', 'template', 'edit', '--id', '12', '--data', file_path]
@@ -44,7 +44,7 @@ class TestTemplateCheck(QdsCliTestCase):
         with open(file_path) as f:
             data = json.load(f)
         Connection._api_call.assert_called_with("PUT", "command_templates/12", data)
-    
+
     def test_edit_template_without_data(self):
         sys.argv = ['qds.py', 'template', 'edit', '--id', '12']
         print_command()
@@ -138,6 +138,14 @@ class TestTemplateCheck(QdsCliTestCase):
         print_command()
         with self.assertRaises(SystemExit):
             qds.main()
+
+    def test_delete_template_operation(self):
+        sys.argv = ['qds-py', 'template', 'delete', '--id', '12']
+        print_command()
+        Connection._api_call = Mock()
+        qds.main()
+        Connection._api_call.assert_called_with("PUT", "command_templates/12/remove", None)
+
 
 def submit_actions_side_effect(*args, **kwargs):
     res = {


### PR DESCRIPTION
  Added delete_template operation to the python sdk this adds a new call to the Templates Resource for deletion of templates. There is a unit test added along with it.
