### PR TITLE
TES 2704: Add support for enable_rubix to qds_sdk

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -270,7 +270,8 @@ def _create_cluster_info(arguments, api_version):
                                       enable_presto=arguments.enable_presto,
                                       bastion_node_public_dns=arguments.bastion_node_public_dns,
                                       role_instance_profile=arguments.role_instance_profile,
-                                      presto_custom_config=presto_custom_config)
+                                      presto_custom_config=presto_custom_config,
+                                      enable_rubix=arguments.enable_rubix)
     else:
         cluster_info = ClusterInfo(arguments.label,
                                    arguments.aws_access_key_id,

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -224,6 +224,17 @@ class Cluster(Resource):
                                               default=None,
                                               help="Do not use Qubole Block Placement policy" +
                                                    " for clusters with spot nodes",)
+          enable_rubix_group = hadoop_group.add_mutually_exclusive_group()
+          enable_rubix_group.add_argument("--enable-rubix",
+                                        dest="enable_rubix",
+                                        action="store_true",
+                                        default=None,
+                                        help="Enable rubix for cluster",)
+          enable_rubix_group.add_argument("--no-enable-rubix",
+                                        dest="enable_rubix",
+                                        action="store_false",
+                                        default=None,
+                                        help="Do not enable rubix for cluster",)
           fallback_to_ondemand_group = node_config_group.add_mutually_exclusive_group()
           fallback_to_ondemand_group.add_argument("--fallback-to-ondemand",
                                  dest="fallback_to_ondemand",
@@ -1052,6 +1063,8 @@ class ClusterInfoV13():
         `presto_custom_config`: Custom Presto configuration overrides.
 
         `bastion_node_public_dns`: Public dns name of the bastion node. Required only if cluster is in private subnet.
+
+        `enable_rubix`: Enable rubix caching on the cluster.
 
         """
 

--- a/qds_sdk/cluster.py
+++ b/qds_sdk/cluster.py
@@ -946,7 +946,8 @@ class ClusterInfoV13():
                          enable_presto=None,
                          bastion_node_public_dns=None,
                          role_instance_profile=None,
-                         presto_custom_config=None):
+                         presto_custom_config=None,
+                         enable_rubix=None):
         """
         Kwargs:
 
@@ -1060,7 +1061,7 @@ class ClusterInfoV13():
         self.set_node_configuration(master_instance_type, slave_instance_type, initial_nodes, max_nodes, slave_request_type, fallback_to_ondemand)
         self.set_ec2_settings(aws_access_key_id, aws_secret_access_key, aws_region, aws_availability_zone, vpc_id, subnet_id,
                                 bastion_node_public_dns, role_instance_profile)
-        self.set_hadoop_settings(custom_config, use_hbase, custom_ec2_tags, use_hadoop2, use_spark, use_qubole_placement_policy)
+        self.set_hadoop_settings(custom_config, use_hbase, custom_ec2_tags, use_hadoop2, use_spark, use_qubole_placement_policy, enable_rubix)
         self.set_spot_instance_settings(maximum_bid_price_percentage, timeout_for_request, maximum_spot_instance_percentage)
         self.set_stable_spot_instance_settings(stable_maximum_bid_price_percentage, stable_timeout_for_request, stable_allow_fallback)
         self.set_ebs_volume_settings(ebs_volume_count, ebs_volume_type, ebs_volume_size)
@@ -1104,12 +1105,14 @@ class ClusterInfoV13():
                             custom_ec2_tags=None,
                             use_hadoop2=None,
                             use_spark=None,
-                            use_qubole_placement_policy=None,):
+                            use_qubole_placement_policy=None,
+                            enable_rubix=None):
         self.hadoop_settings['custom_config'] = custom_config
         self.hadoop_settings['use_hbase'] = use_hbase
         self.hadoop_settings['use_hadoop2'] = use_hadoop2
         self.hadoop_settings['use_spark'] = use_spark
         self.hadoop_settings['use_qubole_placement_policy'] = use_qubole_placement_policy
+        self.hadoop_settings['enable_rubix'] = enable_rubix
 
         if custom_ec2_tags and custom_ec2_tags.strip():
             try:

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1379,6 +1379,36 @@ class TestClusterCreate(QdsCliTestCase):
                  'hadoop_settings': {'use_qubole_placement_policy': False},
                 })
 
+    def test_use_enable_rubix_v13(self):
+        sys.argv = ['qds.py', '--version', 'v1.3', 'cluster', 'create', '--label', 'test_label',
+                '--access-key-id', 'aki', '--secret-access-key', 'sak',
+                '--use-hadoop2', '--enable-rubix']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'label': ['test_label'],
+                 'ec2_settings': {'compute_secret_key': 'sak',
+                                  'compute_access_key': 'aki'},
+                 'hadoop_settings': {'enable_rubix': True,
+                                     'use_hadoop2': True},
+                })
+
+    def test_no_use_enable_rubix_v13(self):
+        sys.argv = ['qds.py', '--version', 'v1.3', 'cluster', 'create', '--label', 'test_label',
+                '--access-key-id', 'aki', '--secret-access-key', 'sak',
+                '--use-hadoop2', '--no-enable-rubix']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'clusters',
+                {'label': ['test_label'],
+                 'ec2_settings': {'compute_secret_key': 'sak',
+                                  'compute_access_key': 'aki'},
+                 'hadoop_settings': {'enable_rubix': False,
+                                     'use_hadoop2': True},
+                })
+
     @unittest.skipIf(sys.version_info < (2, 7, 0), "Known failure on Python 2.6")
     def test_conflict_use_qubole_placement_policy_v13(self):
         sys.argv = ['qds.py', '--version', 'v1.3', 'cluster', 'create', '--label', 'test_label',


### PR DESCRIPTION
This JIRA deals with adding support for enable_rubix inside a cluster to the qds_sdk. It also includes test cases for the same in the test_cluster.py file.