### PR TITLE
SDK-243: Issue while running two different command in different account using qds-sdk

### DIFF
--- a/qds_sdk/qubole.py
+++ b/qds_sdk/qubole.py
@@ -29,6 +29,8 @@ class Qubole:
     poll_interval = None
     skip_ssl_cert_check = None
     cloud_name = None
+    cached_agent = None
+    cloud = None
 
     @classmethod
     def configure(cls, api_token,
@@ -58,11 +60,10 @@ class Qubole:
             cls.poll_interval = poll_interval
         cls.skip_ssl_cert_check = skip_ssl_cert_check
         cls.cloud_name = cloud_name.lower()
+        cls.cached_agent = None
 
 
 
-    cached_agent = None
-    cloud = None
 
 
     @classmethod

--- a/qds_sdk/qubole.py
+++ b/qds_sdk/qubole.py
@@ -63,9 +63,6 @@ class Qubole:
         cls.cached_agent = None
 
 
-
-
-
     @classmethod
     def agent(cls, version=None):
         """


### PR DESCRIPTION
 Clear the cached agent if the configure is called with a different api token. 
This will enable sdk to use two different account tokens in same script