### PR TITLE
fix: dev: SDK-293 Need Spark-Sql support in python sdk for QuboleOper…

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -441,7 +441,7 @@ class SqlCommand(Command):
 class SparkCommand(Command):
 
     usage = ("sparkcmd <submit|run> [options]")
-    allowedlanglist = ["python", "scala","R"]
+    allowedlanglist = ["python", "scala", "R", "command_line", "sql"]
 
     optparser = GentleOptionParser(usage=usage)
     optparser.add_option("--program", dest="program",help=SUPPRESS_HELP)


### PR DESCRIPTION
This PR adds support for sql and command_line programs from SparkCommand