### PR TITLE
retry logic for get requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.5"
 # command to install dependencies
 install:
-  - pip install urllib3==1.22
+  - pip install urllib3==1.22 requests
   - "python setup.py install"
   - pip install mock
   - pip install pytest


### PR DESCRIPTION
This change adds a total of 3 retries for all get requests to avoid failures due to intermittent network issues.