### PR TITLE
chg: dev: SDK-285: Add list functionality to Command to view command history

### DIFF
--- a/bin/qds.py
+++ b/bin/qds.py
@@ -175,6 +175,11 @@ def cancelaction(cmdclass, args):
         sys.stderr.write("Cancel failed with reason '%s'\n" % r.get('result'))
         return 12
 
+def listaction(cmdclass, args):
+    args = cmdclass.listparse(args)
+    if args is not None:
+        return json.dumps(cmdclass.list(**args), indent=4)
+
 
 def getresultaction(cmdclass, args):
     if len(args) > 2:
@@ -206,7 +211,7 @@ def getjobsaction(cmdclass, args):
 def cmdmain(cmd, args):
     cmdclass = CommandClasses[cmd]
 
-    actionset = set(["submit", "run", "check", "cancel", "getresult", "getlog", "getjobs"])
+    actionset = set(["list", "submit", "run", "check", "cancel", "getresult", "getlog", "getjobs"])
     if len(args) < 1:
         sys.stderr.write("missing argument containing action\n")
         usage()

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -57,6 +57,14 @@ class Command(Resource):
         return status == "done"
 
     @classmethod
+    def list(cls, **kwargs):
+        """
+        List a command by issuing a GET request to the /command endpoint
+        """
+        conn = Qubole.agent()
+        return conn.get(cls.rest_entity_path, params=kwargs)
+
+    @classmethod
     def create(cls, **kwargs):
         """
         Create a command object by issuing a POST request to the /command endpoint

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -40,6 +40,22 @@ class Command(Resource):
     """all commands use the /commands endpoint"""
     rest_entity_path = "commands"
 
+    listusage = "<subcommand> list [options]"
+    listparser = GentleOptionParser(usage=listusage)
+    listparser.add_option("-p", "--page", dest="page", type="int",
+                          help="page number")
+    listparser.add_option("-r", "--per-page", dest="per_page", type="int",
+                          help="number of commands to be retrieved per page")
+    listparser.add_option("-a", "--all-users", dest="all_users", type="int", default=0,
+                          help="get the command history of all users. default: 0")
+    listparser.add_option("-i", "--include-query-properties", action="store_true", dest="include_query_properties",
+                          default=False, help="displays query properties such as tags and query history comments. "
+                                              "default: False")
+    listparser.add_option("-s", "--start-date", dest="start_date",
+                          help="the date from which you want the command history")
+    listparser.add_option("-e", "--end-date", dest="end_date",
+                          help="the date until which you want the command history")
+
     @staticmethod
     def is_done(status):
         """
@@ -62,7 +78,23 @@ class Command(Resource):
         List a command by issuing a GET request to the /command endpoint
         """
         conn = Qubole.agent()
-        return conn.get(cls.rest_entity_path, params=kwargs)
+        params = {}
+        for k in kwargs:
+            if kwargs[k]:
+                params[k] = kwargs[k]
+        params = None if not params else params
+        return conn.get(cls.rest_entity_path, params=params)
+
+    @classmethod
+    def listparse(cls, args):
+        try:
+            (options, args) = cls.listparser.parse_args(args)
+        except OptionParsingError as e:
+            raise ParseError(e.msg, cls.listparser.format_help())
+        except OptionParsingExit as e:
+            return None
+
+        return vars(options)
 
     @classmethod
     def create(cls, **kwargs):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -14,6 +14,65 @@ from qds_sdk.connection import Connection
 from test_base import print_command
 from test_base import QdsCliTestCase
 
+
+class TestCommandList(QdsCliTestCase):
+
+    def test_list_minimal(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = None
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_page(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--page', '2']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'page': 2}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_per_page(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--per-page', '5']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'per_page': 5}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_all_users(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--all-users', '1']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'all_users': 1}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_include_query_properties(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--include-query-properties']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'include_query_properties': True}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_start_date(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--start-date', '2019-01-22T15:11:00Z']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'start_date': '2019-01-22T15:11:00Z'}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
+    def test_list_end_date(self):
+        sys.argv = ['qds.py', 'shellcmd', 'list', '--end-date', '2019-01-22T15:11:00Z']
+        print_command()
+        Connection._api_call = Mock(return_value={})
+        params = {'end_date': '2019-01-22T15:11:00Z'}
+        qds.main()
+        Connection._api_call.assert_called_with("GET", "commands", params=params)
+
 class TestCommandCheck(QdsCliTestCase):
 
     @patch("qds.print",create=True)


### PR DESCRIPTION
- Added `list` method to Command base class
- Added parser as per params mentioned in [REST API for Command](https://docs.qubole.com/en/latest/rest-api/command_api/view-command-history.html)
- Added tests