### PR TITLE
Fix Pipeline by Pinning Ubuntu Version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
 # command to run tests
 script: py.test
 env: BOTO_CONFIG=/tmp/nowhere
+dist: trusty


### PR DESCRIPTION
Ubuntu Version got updated by default for Travis CI Builds. Since we hadn't fixed the Ubuntu version our pipelines started using the latest 16.XX version which didn't have python 2.6 and python 3.3