### PR TITLE
SDK-383: Add Retries to all Get requests in case of 500 Response

### DIFF
--- a/qds_sdk/connection.py
+++ b/qds_sdk/connection.py
@@ -50,11 +50,11 @@ class Connection:
             self.session_with_retries = requests.Session()
             self.session_with_retries.mount('https://', MyAdapter(max_retries=3))
 
-    @retry((RetryWithDelay, requests.Timeout), tries=6, delay=30, backoff=2)
+    @retry((RetryWithDelay, requests.Timeout, ServerError), tries=6, delay=30, backoff=2)
     def get_raw(self, path, params=None):
         return self._api_call_raw("GET", path, params=params)
 
-    @retry((RetryWithDelay, requests.Timeout), tries=6, delay=30, backoff=2)
+    @retry((RetryWithDelay, requests.Timeout, ServerError), tries=6, delay=30, backoff=2)
     def get(self, path, params=None):
         return self._api_call("GET", path, params=params)
 


### PR DESCRIPTION
We often see cases when Airflow Jobs fail because the polling API returns a 500 Response. This change adds retries to all get calls when a 500 Response is returned as a result of heavy load on Qubole's Webapp.