### PR TITLE
Validate a JSON response before checking response code

### DIFF
--- a/qds_sdk/connection.py
+++ b/qds_sdk/connection.py
@@ -131,12 +131,12 @@ class Connection:
         else:
             raise NotImplemented
 
+        self._validate_json(r)
         self._handle_error(r)
         return r
 
     def _api_call(self, req_type, path, data=None, params=None):
         response = self._api_call_raw(req_type, path, data=data, params=params)
-        self._validate_json(response)
         return response.json()
 
     @staticmethod


### PR DESCRIPTION
We have seen issues where Qubole API returns 404 HTML response from Nginx and the call fails with resource not found error with retries not kicking in.

Added change to check if it is a proper JSON Response first if it isn't it means that the response came directly from NGINX and didn't reach the web application. Raising Server Error in such cases so that retries can kick in and avoid intermittent issues.