### PR TITLE
SDK-404: Add --skip-upload-to-source option in JupyterNotebookCommand

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1387,6 +1387,9 @@ class JupyterNotebookCommand(Command):
     optparser.add_option("--print-logs-live", action="store_true",
                          dest="print_logs_live", default=False, help="Fetch logs \
                          and print them to stderr while command is running.")
+    optparser.add_option("--skip-upload-to-source", action="store_false",
+                         dest="upload_to_source", default=True, help="Do not \
+                         upload notebook to source after completion of execution")
 
     @classmethod
     def parse(cls, args):

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2096,6 +2096,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2116,6 +2117,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2136,6 +2138,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2156,6 +2159,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2176,6 +2180,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2196,6 +2201,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': True,
                  'pool': None})
 
@@ -2216,6 +2222,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2236,8 +2243,30 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': 'batch'})
+
+    def test_submit_skip_upload_to_source(self):
+        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
+                    '--skip-upload-to-source']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'retry': None,
+                 'name': None,
+                 'tags': None,
+                 'label': None,
+                 'macros': None,
+                 'arguments': None,
+                 'timeout': None,
+                 'path': 'folder/file',
+                 'retry_delay': None,
+                 'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': False,
+                 'can_notify': False,
+                 'pool': None})
 
     def test_submit_retry(self):
         sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
@@ -2256,6 +2285,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 
@@ -2276,6 +2306,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': 2,
                  'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 


### PR DESCRIPTION
Usage: qds.py --token '<token>' --url <url> jupyternotebookcmd submit --path <path> --cluster-label <label> --arguments '{"arg1": "test_without_upload"}' --skip-upload-to-source

Giving the option --skip-upload-to-source would execute the notebook but not overwrite the source notebook with the result notebook of execution.