### PR TITLE
SDK-401: Fix inflection version upgrade on basis of python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,9 +2,13 @@ import os
 import sys
 from setuptools import setup
 
-INSTALL_REQUIRES = ['requests >=2.21.0', 'boto >=2.45.0', 'six >=1.12.0', 'urllib3 >= 1.24.3', 'inflection >= 0.3.1']
+INSTALL_REQUIRES = ['requests >=2.21.0', 'boto >=2.45.0', 'six >=1.12.0', 'urllib3 >= 1.24.3']
 if sys.version_info < (2, 7, 0):
     INSTALL_REQUIRES.append('argparse>=1.1')
+if sys.version_info < (3, 5):
+    INSTALL_REQUIRES.append('inflection==0.3.1')
+else:
+    INSTALL_REQUIRES.append('inflection>=0.3.1')
 
 
 def read(fname):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ import os
 import sys
 from setuptools import setup
 
-INSTALL_REQUIRES = ['requests >=2.21.0', 'boto >=2.45.0', 'six >=1.12.0', 'urllib3 >= 1.24.3']
+INSTALL_REQUIRES = ['requests >=2.21.0', 'boto >=2.45.0', 'six >=1.12.0',
+                    'urllib3 >= 1.24.3']
 if sys.version_info < (2, 7, 0):
     INSTALL_REQUIRES.append('argparse>=1.1')
 if sys.version_info < (3, 5):


### PR DESCRIPTION
Added a check to upgrade inflection only if Python version >= 3.5.

- Inflection 0.4.0 release has dropped support for python version <3.5. 