### PR TITLE
ACM-6842: SDK changes for creating a cluster with hs2 on master (is_hs2)

### DIFF
--- a/qds_sdk/engine.py
+++ b/qds_sdk/engine.py
@@ -241,7 +241,7 @@ class Engine:
                                            dest="presto_custom_config_file",
                                            help="location of file containg custom" +
                                                 " presto configuration overrides")
-        hive_settings_group = argparser.add_argument_group("hive version settings")
+        hive_settings_group = argparser.add_argument_group("hive settings")
         hive_settings_group.add_argument("--hive_version",
                                          dest="hive_version",
                                          default=None,

--- a/qds_sdk/engine.py
+++ b/qds_sdk/engine.py
@@ -28,6 +28,8 @@ class Engine:
                           spark_version=None,
                           custom_spark_config=None,
                           hive_version=None,
+                          is_hs2=None,
+                          hs2_thrift_port=None,
                           dbtap_id=None,
                           fernet_key=None,
                           overrides=None,
@@ -60,6 +62,10 @@ class Engine:
 
             hive_version: Version of hive to be used in cluster
 
+            is_hs2: Enable HS2 on master
+
+            hs2_thrift_port: Thrift port HS2 on master will run on
+
             dbtap_id: ID of the data store inside QDS
 
             fernet_key: Encryption key for sensitive information inside airflow database.
@@ -82,7 +88,7 @@ class Engine:
         self.set_hadoop_settings(custom_hadoop_config, use_qubole_placement_policy,
                                  is_ha, fairscheduler_config_xml,
                                  default_pool, enable_rubix)
-        self.set_hive_settings(hive_version)
+        self.set_hive_settings(hive_version, is_hs2, hs2_thrift_port)
         self.set_presto_settings(presto_version, custom_presto_config)
         self.set_spark_settings(spark_version, custom_spark_config)
         self.set_airflow_settings(dbtap_id, fernet_key, overrides, airflow_version, airflow_python_version)
@@ -110,8 +116,12 @@ class Engine:
         self.hadoop_settings['enable_rubix'] = enable_rubix
 
     def set_hive_settings(self,
-                          hive_version=None):
+                          hive_version=None,
+                          is_hs2=None,
+                          hs2_thrift_port=None):
         self.hive_settings['hive_version'] = hive_version
+        self.hive_settings['is_hs2'] = is_hs2
+        self.hive_settings['hs2_thrift_port'] = hs2_thrift_port
 
     def set_presto_settings(self,
                             presto_version=None,
@@ -158,6 +168,8 @@ class Engine:
                                spark_version=arguments.spark_version,
                                custom_spark_config=arguments.custom_spark_config,
                                hive_version=arguments.hive_version,
+                               is_hs2=arguments.is_hs2,
+                               hs2_thrift_port=arguments.hs2_thrift_port,
                                dbtap_id=arguments.dbtap_id,
                                fernet_key=arguments.fernet_key,
                                overrides=arguments.overrides,
@@ -234,6 +246,14 @@ class Engine:
                                          dest="hive_version",
                                          default=None,
                                          help="Version of hive for the cluster",)
+        hive_settings_group.add_argument("--is_hs2",
+                                         dest="is_hs2",
+                                         default=None,
+                                         help="Enable hs2 on master", )
+        hive_settings_group.add_argument("--hs2_thrift_port",
+                                         dest="hs2_thrift_port",
+                                         default=None,
+                                         help="thrift port hs2 master will run on", )
 
         spark_settings_group = argparser.add_argument_group("spark settings")
         spark_settings_group.add_argument("--spark-version",


### PR DESCRIPTION
Provide functionality to enable HS2 on master for hive clusters while creating/updating.