### PR TITLE
SDK-407, JUPY-884: Add '--upload-to-source' param for JupyterNotebookCommand

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1387,11 +1387,10 @@ class JupyterNotebookCommand(Command):
     optparser.add_option("--print-logs-live", action="store_true",
                          dest="print_logs_live", default=False, help="Fetch logs \
                          and print them to stderr while command is running.")
-    optparser.add_option("--skip-upload-to-source", action="store_false",
-                         dest="upload_to_source", default=True, help="Do not \
-                         upload notebook to source after completion of execution")
-    optparser.add_option("--upload-to-source", dest="upload_to_source", help="Do not \
-                         upload notebook to source after completion of execution")
+    optparser.add_option("--upload-to-source", dest="upload_to_source", default='True',
+                         help="Upload notebook to source after completion of \
+                         execution. Specify value as either True or False. Default \
+                         value is True.")
 
     @classmethod
     def parse(cls, args):
@@ -1419,7 +1418,7 @@ class JupyterNotebookCommand(Command):
                 options.macros = validate_json_input(options.macros, 'Macros', cls)
             if options.retry is not None:
                 options.retry = int(options.retry)
-            if type(options.upload_to_source) is str:
+            if options.upload_to_source is not None:
                 options.upload_to_source = options.upload_to_source.lower()
                 if options.upload_to_source == 'true':
                     options.upload_to_source = True

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1390,6 +1390,8 @@ class JupyterNotebookCommand(Command):
     optparser.add_option("--skip-upload-to-source", action="store_false",
                          dest="upload_to_source", default=True, help="Do not \
                          upload notebook to source after completion of execution")
+    optparser.add_option("--upload-to-source", dest="upload_to_source", help="Do not \
+                         upload notebook to source after completion of execution")
 
     @classmethod
     def parse(cls, args):
@@ -1417,6 +1419,15 @@ class JupyterNotebookCommand(Command):
                 options.macros = validate_json_input(options.macros, 'Macros', cls)
             if options.retry is not None:
                 options.retry = int(options.retry)
+            if type(options.upload_to_source) == str:
+                options.upload_to_source = options.upload_to_source.lower()
+                if options.upload_to_source == 'true':
+                    options.upload_to_source = True
+                elif options.upload_to_source == 'false':
+                    options.upload_to_source = False
+                else:
+                    msg = 'Upload to Source parameter takes value of either True or False only.'
+                    raise ParseError(msg, cls.optparser.format_help())
         except OptionParsingError as e:
             raise ParseError(e.msg, cls.optparser.format_help())
         except OptionParsingExit as e:

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1389,8 +1389,8 @@ class JupyterNotebookCommand(Command):
                          and print them to stderr while command is running.")
     optparser.add_option("--upload-to-source", dest="upload_to_source", default='True',
                          help="Upload notebook to source after completion of \
-                         execution. Specify value as either True or False. Default \
-                         value is True.")
+                         execution. Specify the value as either'true' or 'false'. Default \
+                         value is 'true' ")
 
     @classmethod
     def parse(cls, args):

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1419,14 +1419,15 @@ class JupyterNotebookCommand(Command):
                 options.macros = validate_json_input(options.macros, 'Macros', cls)
             if options.retry is not None:
                 options.retry = int(options.retry)
-            if type(options.upload_to_source) == str:
+            if type(options.upload_to_source) is str:
                 options.upload_to_source = options.upload_to_source.lower()
                 if options.upload_to_source == 'true':
                     options.upload_to_source = True
                 elif options.upload_to_source == 'false':
                     options.upload_to_source = False
                 else:
-                    msg = 'Upload to Source parameter takes value of either True or False only.'
+                    msg = 'Upload to Source parameter takes value of either True \
+                    or False only.'
                     raise ParseError(msg, cls.optparser.format_help())
         except OptionParsingError as e:
             raise ParseError(e.msg, cls.optparser.format_help())

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1387,10 +1387,10 @@ class JupyterNotebookCommand(Command):
     optparser.add_option("--print-logs-live", action="store_true",
                          dest="print_logs_live", default=False, help="Fetch logs \
                          and print them to stderr while command is running.")
-    optparser.add_option("--upload-to-source", dest="upload_to_source", default='True',
+    optparser.add_option("--upload-to-source", dest="upload_to_source", default='true',
                          help="Upload notebook to source after completion of \
-                         execution. Specify the value as either'true' or 'false'. Default \
-                         value is 'true' ")
+                         execution. Specify the value as either 'true' or 'false'.\
+                         Default value is 'true'.")
 
     @classmethod
     def parse(cls, args):

--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -1425,8 +1425,8 @@ class JupyterNotebookCommand(Command):
                 elif options.upload_to_source == 'false':
                     options.upload_to_source = False
                 else:
-                    msg = 'Upload to Source parameter takes value of either True \
-                    or False only.'
+                    msg = "Upload to Source parameter takes a value of either 'true' \
+                    or 'false' only."
                     raise ParseError(msg, cls.optparser.format_help())
         except OptionParsingError as e:
             raise ParseError(e.msg, cls.optparser.format_help())

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2268,6 +2268,55 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'can_notify': False,
                  'pool': None})
 
+    def test_submit_upload_to_source(self):
+        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
+                    '--upload-to-source', 'True']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'retry': None,
+                 'name': None,
+                 'tags': None,
+                 'label': None,
+                 'macros': None,
+                 'arguments': None,
+                 'timeout': None,
+                 'path': 'folder/file',
+                 'retry_delay': None,
+                 'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': True,
+                 'can_notify': False,
+                 'pool': None})
+
+    def test_submit_upload_to_source_false(self):
+        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
+                    '--upload-to-source', 'False']
+        print_command()
+        Connection._api_call = Mock(return_value={'id': 1234})
+        qds.main()
+        Connection._api_call.assert_called_with('POST', 'commands',
+                {'retry': None,
+                 'name': None,
+                 'tags': None,
+                 'label': None,
+                 'macros': None,
+                 'arguments': None,
+                 'timeout': None,
+                 'path': 'folder/file',
+                 'retry_delay': None,
+                 'command_type': 'JupyterNotebookCommand',
+                 'upload_to_source': False,
+                 'can_notify': False,
+                 'pool': None})
+
+    def test_submit_upload_to_source_wrong_param(self):
+        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
+                    '--upload-to-source', 'wrong']
+        print_command()
+        with self.assertRaises(qds_sdk.exception.ParseError):
+            qds.main()
+
     def test_submit_retry(self):
         sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
                     '--retry', '1']

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -2247,9 +2247,8 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'can_notify': False,
                  'pool': 'batch'})
 
-    def test_submit_skip_upload_to_source(self):
-        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file',
-                    '--skip-upload-to-source']
+    def test_submit_no_upload_to_source(self):
+        sys.argv = ['qds.py', 'jupyternotebookcmd', 'submit', '--path', 'folder/file']
         print_command()
         Connection._api_call = Mock(return_value={'id': 1234})
         qds.main()
@@ -2264,7 +2263,7 @@ class TestJupyterNotebookCommand(QdsCliTestCase):
                  'path': 'folder/file',
                  'retry_delay': None,
                  'command_type': 'JupyterNotebookCommand',
-                 'upload_to_source': False,
+                 'upload_to_source': True,
                  'can_notify': False,
                  'pool': None})
 


### PR DESCRIPTION
Airflow does not support boolean flags. Thus, we are removing '--skip-upload-to-source' option in JupyterNotebookCommand and adding '--upload-to-source' option.

The valid arguments to this option include 'True' and 'False'. Passing any other value would raise a ParseError.