### PR TITLE
SDK:419 : Adding support for passing extra arguments for boto's conne…

### DIFF
--- a/qds_sdk/commands.py
+++ b/qds_sdk/commands.py
@@ -252,7 +252,7 @@ class Command(Resource):
         return r.text
 
 
-    def get_results(self, fp=sys.stdout, inline=True, delim=None, fetch=True, qlog=None, arguments=[]):
+    def get_results(self, fp=sys.stdout, inline=True, delim=None, fetch=True, qlog=None, arguments=[], boto_args={}):
         """
         Fetches the result for the command represented by this object
 
@@ -307,7 +307,8 @@ class Command(Resource):
                 boto_conn = boto.connect_s3(aws_access_key_id=storage_credentials['storage_access_key'],
                                             aws_secret_access_key=storage_credentials['storage_secret_key'],
                                             security_token=storage_credentials['session_token'],
-                                            host=host)
+                                            host=host,
+                                            **boto_args)
                 log.info("Starting download from result locations: [%s]" % ",".join(r['result_location']))
                 # fetch latest value of num_result_dir
                 num_result_dir = Command.find(self.id).num_result_dir


### PR DESCRIPTION
This will enable the user to pass extra paramters as boto_args in command's result fetch which is then being passed to boto's connec_s3 function to give a flexibility to tune it accordingly.